### PR TITLE
Add undefined check to avoid TypeError in quiet mode

### DIFF
--- a/audit.js
+++ b/audit.js
@@ -159,7 +159,7 @@ if (program['quiet']) {
 /** Hack code to allow us to check if a specific logger level is enabled.
  */
 logger.isLevelEnabled = function(level) {
-  if (this.transports) {
+  if (this.transports && this.transports.console) {
     var levels = this.transports.console.level;
     return levels == level;
   }


### PR DESCRIPTION
## What's new?
Added a simple undefined sanity check

## What does this fix?
Identified issue - [--quiet flag throws TypeError](https://github.com/OSSIndex/auditjs/issues/43)

## Why did a `TypeError` happen here in the first place?
In verbose mode, a new `winston.Logger` instance is created like so:
```
logger = new (winston.Logger)({
    transports: [
      new (winston.transports.Console)({
        level: process.env.LOG_LEVEL ||
          (program['verbose']?'verbose':false) ||
          (LOGGER_LEVELS.includes(program['level'])?program['level']:false)
          || 'info',
        formatter: logFormatter})
    ]
  });
```
Quiet mode creates its `winston.Logger` instance with just `logger = new (winston.Logger)();` The notable difference between the two is that `verbose` creates a `transports` property as an array, whereas `quiet` does not.

Except - it does! Implicitly. That's now the `winston.Logger` constructor works.

So the `if (this.transports)` check returns true for both quiet mode and verbose mode. The assumption was made that if `this.transports` exists, so must `this.transports.console`. But it doesn't, in the case of quiet mode. Hence the `TypeError`.