### PR TITLE
Fix read installed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,10 @@
       "type": "node",
       "request": "launch",
       "name": "Launch With OSS Index",
-      "args": ["ossi"],
+      "args": ["ossi", "--dev"],
       "program": "${workspaceFolder}/src/index.ts",
       "preLaunchTask": "tsc: build - tsconfig.json",
-      "outFiles": ["${workspaceFolder}/bin/**/*.js"]
+      "outFiles": ["${workspaceFolder}/bin/**/*.js"],
     },
     {
       "type": "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,11 @@
         "@types/node": "*"
       }
     },
+    "@types/js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -205,7 +210,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -565,8 +569,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -768,7 +771,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1639,8 +1641,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssri": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@cyclonedx/bom": "^1.0.4",
     "@types/figlet": "^1.2.0",
+    "@types/js-yaml": "^3.12.1",
     "@types/node": "^12.12.17",
     "@types/node-fetch": "^2.5.4",
     "@types/node-persist": "^3.0.0",
@@ -65,6 +66,7 @@
     "chalk": "^3.0.0",
     "colors": "^1.3.1",
     "figlet": "^1.2.4",
+    "js-yaml": "^3.13.1",
     "node-fetch": "^2.6.0",
     "node-persist": "^3.0.5",
     "ora": "^4.0.3",

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -251,25 +251,25 @@ export class Application {
 
   private getIqRequestService(args: any): IqRequestService {
     try {
-      let config = new IqServerConfig();
-
-      config.getConfigFromFile();
-
-      if (this.checkDefaultIQValues(config)) {
+      if (!this.checkDefaultIQValuesFromCommandLine(args)) {
         return new IqRequestService(
           args.user as string, 
           args.password as string, 
           args.server as string, 
           args.application as string,
           args.stage as string);
-      } else {
-        return new IqRequestService(
-          config.getUsername(), 
-          config.getToken(), 
-          config.getHost(), 
-          args.application as string,
-          args.stage as string);
       }
+
+      let config = new IqServerConfig();
+
+      config.getConfigFromFile();
+
+      return new IqRequestService(
+        config.getUsername(), 
+        config.getToken(), 
+        config.getHost(), 
+        args.application as string,
+        args.stage as string);
     } catch (e) {
       return new IqRequestService(
         args.user as string, 
@@ -280,8 +280,8 @@ export class Application {
     }
   }
 
-  private checkDefaultIQValues(config: IqServerConfig): boolean {
-    if (config.getUsername() === 'admin' && config.getToken() === 'admin123' && config.getHost() === 'http://localhost:8070') {
+  private checkDefaultIQValuesFromCommandLine(args: any): boolean {
+    if (args.user === 'admin' && args.password === 'admin123' && args.server === 'http://localhost:8070') {
       // TODO: Probably issue some warning to user about doing very silly things with config
       return true;
     }

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -250,7 +250,11 @@ export class Application {
   }
 
   private getIqRequestService(args: any): IqRequestService {
-    if (args.user && args.password && args.server) {
+    let config = new IqServerConfig();
+
+    config.getConfigFromFile();
+    
+    if (this.checkDefaultIQValues(config)) {
       return new IqRequestService(
         args.user as string, 
         args.password as string, 
@@ -259,10 +263,6 @@ export class Application {
         args.stage as string);
     }
     try {
-      let config = new IqServerConfig();
-
-      config.getConfigFromFile();
-
       return new IqRequestService(
         config.getUsername(), 
         config.getToken(), 
@@ -272,5 +272,13 @@ export class Application {
     } catch (e) {
       throw new Error(e);
     }
+  }
+
+  private checkDefaultIQValues(config: IqServerConfig): boolean {
+    if (config.getUsername() === 'admin' && config.getToken() === 'admin123' && config.getHost() === 'http://localhost:8070') {
+      // TODO: Probably issue some warning to user about doing very silly things with config
+      return true;
+    }
+    return false;
   }
 }

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -250,27 +250,33 @@ export class Application {
   }
 
   private getIqRequestService(args: any): IqRequestService {
-    let config = new IqServerConfig();
+    try {
+      let config = new IqServerConfig();
 
-    config.getConfigFromFile();
-    
-    if (this.checkDefaultIQValues(config)) {
+      config.getConfigFromFile();
+
+      if (this.checkDefaultIQValues(config)) {
+        return new IqRequestService(
+          args.user as string, 
+          args.password as string, 
+          args.server as string, 
+          args.application as string,
+          args.stage as string);
+      } else {
+        return new IqRequestService(
+          config.getUsername(), 
+          config.getToken(), 
+          config.getHost(), 
+          args.application as string,
+          args.stage as string);
+      }
+    } catch (e) {
       return new IqRequestService(
         args.user as string, 
         args.password as string, 
         args.server as string, 
         args.application as string,
         args.stage as string);
-    }
-    try {
-      return new IqRequestService(
-        config.getUsername(), 
-        config.getToken(), 
-        config.getHost(), 
-        args.application as string,
-        args.stage as string);
-    } catch (e) {
-      throw new Error(e);
     }
   }
 

--- a/src/Config/AppConfig.ts
+++ b/src/Config/AppConfig.ts
@@ -16,6 +16,7 @@
 import readline from 'readline';
 import { OssIndexServerConfig } from './OssIndexServerConfig';
 import { IqServerConfig } from './IqServerConfig';
+import { ConfigPersist } from './ConfigPersist';
 
 export class AppConfig {
   private rl: readline.Interface;
@@ -58,14 +59,12 @@ export class AppConfig {
       );
   
       this.rl.close();
-  
-      let config = new IqServerConfig(
-        username, 
-        token, 
-        host.endsWith('/') ? host.slice(0, host.length - 1) : host
-      );
+
+      let iqConfig = new ConfigPersist(username, token, host.endsWith('/') ? host.slice(0, host.length - 1) : host)
+
+      let config = new IqServerConfig();
       
-      return config.saveFile();
+      return config.saveFile(iqConfig);
     } else {
       username = await this.setVariable(
         'What is your username? '
@@ -77,9 +76,11 @@ export class AppConfig {
   
       this.rl.close();
   
+      let ossIndexConfig = new ConfigPersist(username, token);
+
       let config = new OssIndexServerConfig(username, token);
       
-      return config.saveFile();
+      return config.saveFile(ossIndexConfig);
     }
   }
 

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -18,6 +18,9 @@ import { homedir } from 'os';
 import { mkdirSync, existsSync } from 'fs';
 import { Logger } from 'winston';
 import { writeFileSync } from "fs";
+import { safeDump } from 'js-yaml';
+
+import { ConfigPersist } from './ConfigPersist';
 
 export abstract class Config {
   constructor(
@@ -45,11 +48,11 @@ export abstract class Config {
   }
 
   protected saveConfigToFile(
-    stringToSave: string,
+    objectToSave: ConfigPersist,
     saveLocation: string = '.oss-index-config'
   ): boolean {
     try {
-      writeFileSync(this.getSaveLocation(saveLocation), stringToSave);
+      writeFileSync(this.getSaveLocation(saveLocation), safeDump(objectToSave, { skipInvalid: true}));
       return true;
     } catch (e) {
       throw new Error(e);
@@ -58,7 +61,5 @@ export abstract class Config {
 
   abstract getConfigFromFile(saveLocation?: string): Config;
 
-  abstract getStringToSave(): string;
-
-  abstract saveFile(): boolean;
+  abstract saveFile(configToSave: ConfigPersist): boolean;
 }

--- a/src/Config/ConfigPersist.ts
+++ b/src/Config/ConfigPersist.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class ConfigPersist {
+  constructor(readonly Username: string,
+    readonly Token: string,
+    readonly Server?: string) {}
+}

--- a/src/Config/IqServerConfig.spec.ts
+++ b/src/Config/IqServerConfig.spec.ts
@@ -19,6 +19,7 @@ import mock from 'mock-fs';
 import { readFileSync } from 'fs';
 import sinon from 'sinon';
 import os from 'os';
+import { ConfigPersist } from './ConfigPersist';
 
 describe("IqServerConfig", async () => {
   it("should return true when it is able to save a config file", async () => {
@@ -26,11 +27,14 @@ describe("IqServerConfig", async () => {
     mock({ '/nonsense': {}});
 
     let config = new IqServerConfig("username", "password", "http://localhost:8070");
-    expect(config.saveFile()).to.equal(true);
+    let configPersist = new ConfigPersist("username", "password", "http://localhost:8070")
+    expect(config.saveFile(configPersist)).to.equal(true);
 
-    let file = readFileSync('/nonsense/.iqserver/.iq-server-config');
+    let conf = config.getConfigFromFile('/nonsense/.iqserver/.iq-server-config');
 
-    expect(file.toString()).to.equal('Username: username\nPassword: password\nHost: http://localhost:8070\n');
+    expect(conf.getUsername()).to.equal('username');
+    expect(conf.getToken()).to.equal('password');
+    expect(conf.getHost()).to.equal('http://localhost:8070');
     mock.restore();
     sinon.restore();
   });

--- a/src/Config/IqServerConfig.ts
+++ b/src/Config/IqServerConfig.ts
@@ -17,6 +17,8 @@ import { Config } from "./Config";
 import { readFileSync } from "fs";
 import { Logger } from "winston";
 import { getAppLogger } from "../Application/Logger/Logger";
+import { ConfigPersist } from "./ConfigPersist";
+import { safeLoad } from 'js-yaml';
 
 export class IqServerConfig extends Config {
   constructor(
@@ -28,8 +30,8 @@ export class IqServerConfig extends Config {
     super(username, token, logger);
   }
 
-  public saveFile(stringToSave: string = this.getStringToSave()): boolean {
-    return super.saveConfigToFile(stringToSave, '.iq-server-config');
+  public saveFile(iqServerConfig: ConfigPersist): boolean {
+    return super.saveConfigToFile(iqServerConfig, '.iq-server-config');
   }
 
   public getUsername(): string {
@@ -47,17 +49,11 @@ export class IqServerConfig extends Config {
   public getConfigFromFile(
     saveLocation: string = this.getSaveLocation('.iq-server-config')
   ): IqServerConfig {
-    let fileString = readFileSync(saveLocation, 'utf8');
-    let splitString = fileString.split('\n');
-    super.username = splitString[0].split(':')[1].trim();
-    super.token = splitString[1].split(':')[1].trim();
-    let temp = splitString[2].split(':');
-    this.host = temp.slice(1).join(':').trim();
+    const doc = safeLoad(readFileSync(saveLocation, 'utf8'));
+    super.username = doc.Username;
+    super.token = doc.Token;
+    this.host = doc.Server;
 
     return this;
-  }
-
-  public getStringToSave(): string {
-    return `Username: ${this.username}\nPassword: ${this.token}\nHost: ${this.host}\n`;
   }
 }

--- a/src/Config/OssIndexServerConfig.spec.ts
+++ b/src/Config/OssIndexServerConfig.spec.ts
@@ -19,6 +19,7 @@ import mock from 'mock-fs';
 import { readFileSync } from 'fs';
 import sinon from 'sinon';
 import os from 'os';
+import { ConfigPersist } from './ConfigPersist';
 
 describe("OssIndexServerConfig", async () => {
   it("should return true when it is able to save a config file", async () => {
@@ -26,11 +27,13 @@ describe("OssIndexServerConfig", async () => {
     mock({ '/nonsense': {}});
 
     let config = new OssIndexServerConfig("username", "password");
-    expect(config.saveFile()).to.equal(true);
+    let configPersist = new ConfigPersist("username", "password")
+    expect(config.saveFile(configPersist)).to.equal(true);
 
-    let file = readFileSync('/nonsense/.ossindex/.oss-index-config');
+    let conf = config.getConfigFromFile('/nonsense/.ossindex/.oss-index-config');
 
-    expect(file.toString()).to.equal('Username: username\nPassword: password\n');
+    expect(conf.getUsername()).to.equal('username');
+    expect(conf.getToken()).to.equal('password');
     mock.restore();
     sinon.restore();
   });

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -17,6 +17,8 @@ import { Config } from "./Config";
 import { readFileSync } from "fs";
 import { getAppLogger } from "../Application/Logger/Logger";
 import { Logger } from "winston";
+import { ConfigPersist } from "./ConfigPersist";
+import { safeLoad } from 'js-yaml';
 
 export class OssIndexServerConfig extends Config {
 
@@ -35,22 +37,17 @@ export class OssIndexServerConfig extends Config {
     return this.token;
   }
 
-  public saveFile(stringToSave: string = this.getStringToSave()): boolean {
-    return super.saveConfigToFile(stringToSave);
+  public saveFile(ossIndexConfig: ConfigPersist): boolean {
+    return super.saveConfigToFile(ossIndexConfig);
   }
 
   public getConfigFromFile(
     saveLocation: string = this.getSaveLocation('.oss-index-config')
   ): OssIndexServerConfig {
-    let fileString = readFileSync(saveLocation, 'utf8');
-    let splitString = fileString.split('\n');
-    super.username = splitString[0].split(':')[1].trim();
-    super.token = splitString[1].split(':')[1].trim();
+    const doc = safeLoad(readFileSync(saveLocation, 'utf8'));
+    super.username = doc.Username;
+    super.token = doc.Token;
 
     return this;
-  }
-
-  public getStringToSave(): string {
-    return `Username: ${this.username}\nPassword: ${this.token}\n`;
   }
 }

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -78,14 +78,8 @@ export class NpmList implements Muncher {
       return;
     }
     if (!isRootPkg) {
-      if (objectTree.name && objectTree.name.includes('/')) {
-        let name = objectTree.name.split('/');
-        if (list.find((x) => { return (x.name == name[1] && x.version == objectTree.version && x.group == name[0])})) { return; }
-        list.push(new Coordinates(name[1], objectTree.version, name[0]));
-      }
-      else if (objectTree.name) {
-        if (list.find((x) => { return (x.name == objectTree.name && x.version == objectTree.version)})) { return; }
-        list.push(new Coordinates(objectTree.name, objectTree.version, ''))
+      if (this.maybePushNewCoordinate(objectTree, list)) {
+        // NO OP
       }
       else {
         return;
@@ -96,7 +90,12 @@ export class NpmList implements Muncher {
         .map((x) => objectTree.dependencies[x])
         .filter((x) => typeof(x) !== 'string')
         .map((dep) => {
-          if (this.toPurlObjTre(objectTree) == '' || list.find((x) => { return x.toPurl() == this.toPurlObjTre(objectTree) })) {
+          if (
+            this.toPurlObjTree(objectTree) == '' || 
+            list.find((x) => { 
+              return x.toPurl() == this.toPurlObjTree(objectTree) 
+              })
+            ) {
             return; 
           } else {
             this.recurseObjectTree(dep, list, false);
@@ -106,7 +105,32 @@ export class NpmList implements Muncher {
     return;
   }
 
-  private toPurlObjTre(objectTree: any): string {
+  private maybePushNewCoordinate(pkg: any, list: Array<Coordinates>): boolean {
+    if (pkg.name && pkg.name.includes('/')) {
+      let name = pkg.name.split('/');
+      if (list.find((x) => { 
+        return (x.name == name[1] && x.version == pkg.version && x.group == name[0])
+        })
+      ) { 
+        return false 
+      }
+      list.push(new Coordinates(name[1], pkg.version, name[0]));
+      return true;
+    }
+    else if (pkg.name) {
+      if (list.find((x) => { 
+        return (x.name == pkg.name && x.version == pkg.version)
+        })
+      ) { 
+        return false 
+      }
+      list.push(new Coordinates(pkg.name, pkg.version, ''))
+      return true;
+    }
+    return false;
+  }
+
+  private toPurlObjTree(objectTree: any): string {
     if (objectTree.name && objectTree.name.includes('/')) {
       let name = objectTree.name.split('/');
 


### PR DESCRIPTION
So we started using `read-installed` to get the deps, rather than using the npm cli, etc... as it seems to be more reliable. However, it's pretty tricky to use, and this branch is to clean it up so that we are using it "correctly".

This branch also fixes our Config, as I ran into issues with this being we are starting to move over other tools to use `yaml` for backing on config.