### PR TITLE
Fix: Trailing slash in host lead to an error object being returned

### DIFF
--- a/src/Config/AppConfig.ts
+++ b/src/Config/AppConfig.ts
@@ -60,7 +60,7 @@ export class AppConfig {
   
       this.rl.close();
 
-      let iqConfig = new ConfigPersist(username, token, host.endsWith('/') ? host.slice(0, host.length - 1) : host)
+      let iqConfig = new ConfigPersist(username, token, this.removeTrailingSlash(host));
 
       let config = new IqServerConfig();
       
@@ -82,6 +82,10 @@ export class AppConfig {
       
       return config.saveFile(ossIndexConfig);
     }
+  }
+
+  private removeTrailingSlash(host: string): string {
+    return host.replace(/\/+$/, '');
   }
 
   private setVariable(message: string, defaultValue: string = ''): Promise<string> {


### PR DESCRIPTION
Resolves #105.

While we had logic to handle trailing slashes in place, for whatever reason it wasn't firing off correctly. I opted to create a private method that used RegEx instead -- Not sure if RegEx is the way to go, would want @DarthHater to sign off and approve before merging @ajurgenson55 