### PR TITLE
Revert "Fix: Trailing slash in host lead to an error object being returned"

### DIFF
--- a/src/Config/AppConfig.ts
+++ b/src/Config/AppConfig.ts
@@ -60,7 +60,7 @@ export class AppConfig {
   
       this.rl.close();
 
-      let iqConfig = new ConfigPersist(username, token, this.removeTrailingSlash(host));
+      let iqConfig = new ConfigPersist(username, token, host.endsWith('/') ? host.slice(0, host.length - 1) : host)
 
       let config = new IqServerConfig();
       
@@ -82,10 +82,6 @@ export class AppConfig {
       
       return config.saveFile(ossIndexConfig);
     }
-  }
-
-  private removeTrailingSlash(host: string): string {
-    return host.replace(/\/+$/, '');
   }
 
   private setVariable(message: string, defaultValue: string = ''): Promise<string> {


### PR DESCRIPTION
Reverts sonatype-nexus-community/auditjs#108

@DarthHater provided a better and more comprehensive fix last night