### PR TITLE
Fix: more robust solution to concat host with url

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -255,7 +255,7 @@ export class Application {
         return new IqRequestService(
           args.user as string, 
           args.password as string, 
-          args.server as string, 
+          this.chompHost(args.server), 
           args.application as string,
           args.stage as string);
       }
@@ -274,10 +274,17 @@ export class Application {
       return new IqRequestService(
         args.user as string, 
         args.password as string, 
-        args.server as string, 
+        this.chompHost(args.server), 
         args.application as string,
         args.stage as string);
     }
+  }
+
+  private chompHost(host: string): string {
+    if (host.endsWith('/')) {
+      return host.substr(0, host.length -1);
+    }
+    return host;
   }
 
   private checkDefaultIQValuesFromCommandLine(args: any): boolean {

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -255,7 +255,7 @@ export class Application {
         return new IqRequestService(
           args.user as string, 
           args.password as string, 
-          this.chompHost(args.server), 
+          args.server as string, 
           args.application as string,
           args.stage as string);
       }
@@ -274,17 +274,10 @@ export class Application {
       return new IqRequestService(
         args.user as string, 
         args.password as string, 
-        this.chompHost(args.server), 
+        args.server as string, 
         args.application as string,
         args.stage as string);
     }
-  }
-
-  private chompHost(host: string): string {
-    if (host.endsWith('/')) {
-      return host.substr(0, host.length -1);
-    }
-    return host;
   }
 
   private checkDefaultIQValuesFromCommandLine(args: any): boolean {

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -212,7 +212,7 @@ export class Application {
       this.spinner.maybeSucceed();
       this.spinner.maybeCreateMessageForSpinner('Checking for results (this could take a minute)');
       logMessage('Polling Nexus IQ Server for report results', DEBUG, resultUrl);
-      requestService.asyncPollForResults(`${requestService.host}/${resultUrl}`, (x) => {
+      requestService.asyncPollForResults(`${resultUrl}`, (x) => {
         this.spinner.maybeSucceed();
         this.spinner.maybeCreateMessageForSpinner('Auditing your results');
         const results: ReportStatus = Object.assign(new ReportStatus(), x);

--- a/src/Services/IqRequestService.ts
+++ b/src/Services/IqRequestService.ts
@@ -48,8 +48,8 @@ export class IqRequestService {
   public async submitToThirdPartyAPI(data: any, internalId: string) {
     const response = await fetch(
       `${this.host}/api/v2/scan/applications/${internalId}/sources/auditjs?stageId=${this.stage}`,
-      { method: 'post', headers: [this.getBasicAuth(), RequestHelpers.getUserAgent(), ["Content-Type", "application/xml"]], body: data});
-    
+      { method: 'post', headers: [this.getBasicAuth(), RequestHelpers.getUserAgent(), ["Content-Type", "application/xml"]], body: data}
+    );
     if (response.ok) {
       let json = await response.json();
       return json.statusUrl as string;

--- a/src/Services/IqRequestService.ts
+++ b/src/Services/IqRequestService.ts
@@ -78,7 +78,7 @@ export class IqRequestService {
   public async asyncPollForResults(url: string, pollingFinished: (body: any) => any) {
     // https://www.youtube.com/watch?v=Pubd-spHN-0
     const response = await fetch(
-      url, { 
+      this.getURLOrMerge(url).href, { 
         method: 'get', 
         headers: [this.getBasicAuth(), RequestHelpers.getUserAgent()]
       });
@@ -88,6 +88,17 @@ export class IqRequestService {
     } else {
       let json = await response.json();
       pollingFinished(json);
+    }
+  }
+
+  private getURLOrMerge(url: string): URL {
+    try {
+      return new URL(url);
+    } catch (e) {
+      if (url.substr(0, 1) === '/') {
+        return new URL(this.host.concat(url)); 
+      }
+      return new URL(this.host.concat('/' + url)); 
     }
   }
 

--- a/src/Services/IqRequestService.ts
+++ b/src/Services/IqRequestService.ts
@@ -95,7 +95,7 @@ export class IqRequestService {
     try {
       return new URL(url);
     } catch (e) {
-      if (url.substr(0, 1) === '/') {
+      if (url[0] === '/') {
         return new URL(this.host.concat(url)); 
       }
       return new URL(this.host.concat('/' + url)); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,13 @@ let argv = yargs
       },
       )
     })
+  .check((argv) => {
+    if (argv.server && (argv.server as string).endsWith('/')) {
+      throw new Error("Server url should be missing trailing slash");
+    } else {
+      return true;
+    }
+  })
   .argv;
 
 if (argv) {


### PR DESCRIPTION
This PR fixes three things:
1) It has a more robust way of concat'ing host with the url (for IQ Server requests)
2) The concat'ing logic also handles trailing `/` when `auditjs config` is run
3) The logic should resolve #110 