### PR TITLE
Junit xml format output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Options:
   --quiet, -q      Only print out vulnerable dependencies              [boolean]
   --verbose, -V    Set console logging level to verbose                [boolean]
   --json, -j       Set output to JSON                                  [boolean]
+  --xml, -x        Set output to JUnit XML format                      [boolean]
   --whitelist, -w  Set path to whitelist file                           [string]
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,6 +1917,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ora": "^4.0.3",
     "read-installed": "~4.0.3",
     "winston": "^3.2.1",
+    "xmlbuilder": "^13.0.2",
     "yargs": "^15.0.2"
   }
 }

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -173,7 +173,7 @@ export class Application {
 
       this.spinner.maybeCreateMessageForSpinner('Auditing your results from Sonatype OSS Index');
       logMessage('Instantiating OSS Index Request Service, with quiet option', DEBUG, { quiet: args.quiet });
-      let auditOSSIndex = new AuditOSSIndex((args.quiet) ? true : false, (args.json) ? true : false);
+      let auditOSSIndex = new AuditOSSIndex((args.quiet) ? true : false, (args.json) ? true : false, (args.xml) ? true : false);
       this.spinner.maybeStop();
 
       logMessage('Attempting to audit results', DEBUG);

--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -79,7 +79,7 @@ export class AuditOSSIndex {
       if (vulns) {
         if (vulns.length > 0) {
           for (let j: number = 0; j < vulns.length; j++) {
-            let failure = testcase.ele("failure", { "type": vulns[j].title }, vulns[j].description);
+            let failure = testcase.ele("failure", { "type": vulns[j].title }, this.getVulnerabilityForXmlBlock(vulns[j]));
           }
         }
       }
@@ -93,6 +93,19 @@ export class AuditOSSIndex {
       return true;
     }
     return false;
+  }
+
+  private getVulnerabilityForXmlBlock(vuln: Vulnerability): string {
+    let vulnBlock = "";
+    vulnBlock += `Vulnerability Title: ${vuln.title}\n`;
+    vulnBlock += `ID: ${vuln.id}\n`;
+    vulnBlock += `Description: ${vuln.description}\n`;
+    vulnBlock += `CVSS Score: ${vuln.cvssScore}\n`;
+    vulnBlock += `CVSS Vector: ${vuln.cvssVector}\n`;
+    vulnBlock += `CVE: ${vuln.cve}\n`;
+    vulnBlock += `Reference: ${vuln.reference}\n`;
+
+    return vulnBlock;
   }
 
   private getColorFromMaxScore(maxScore: number, defaultColor: string = 'darkblue'): string {

--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -62,7 +62,7 @@ export class AuditOSSIndex {
   private printJson(results: Array<OssIndexServerResult>): boolean {
     console.log(JSON.stringify(results, null, 2));
 
-    if (results.filter((x) => { return (x.vulnerabilities && x.vulnerabilities?.length > 0) }).length > 0) {
+    if (this.getNumberOfVulnerablePackagesFromResults(results) > 0) {
       return true;
     }
     return false;
@@ -71,6 +71,8 @@ export class AuditOSSIndex {
   private printJUnitXML(results: Array<OssIndexServerResult>): boolean {
     let testsuite = builder.create('testsuite');
     testsuite.att('tests', results.length);
+    testsuite.att('timestamp', new Date().toISOString());
+    testsuite.att('failures', this.getNumberOfVulnerablePackagesFromResults(results));
 
     for(let i: number = 0; i < results.length; i++) {
       let testcase = testsuite.ele("testcase", {"classname": results[i].coordinates, "name": results[i].coordinates});
@@ -89,10 +91,14 @@ export class AuditOSSIndex {
     
     console.log(xml);
 
-    if (results.filter((x) => { return (x.vulnerabilities && x.vulnerabilities?.length > 0) }).length > 0) {
+    if (this.getNumberOfVulnerablePackagesFromResults(results) > 0) {
       return true;
     }
     return false;
+  }
+
+  private getNumberOfVulnerablePackagesFromResults(results: Array<OssIndexServerResult>): number {
+    return results.filter((x) => { return (x.vulnerabilities && x.vulnerabilities?.length > 0) }).length;
   }
 
   private getVulnerabilityForXmlBlock(vuln: Vulnerability): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,12 @@ let argv = yargs
           description: 'Set output to JSON',
           demandOption: false
         },
+        xml: {
+          alias: 'x',
+          type: 'boolean',
+          description: 'Set output to JUnit XML format',
+          demandOption: false
+        },
         whitelist: {
           alias: 'w',
           type: 'string',
@@ -152,7 +158,7 @@ if (argv) {
         throw new Error(e);
       });
   } else {
-    let silence = (argv.json || argv.quiet) ? true : false;
+    let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;
 
     if (argv.server) {


### PR DESCRIPTION
Quick lil ditty to output things in a JUnit xml format.

Format stolen from: https://stackoverflow.com/questions/4922867/what-is-the-junit-xml-format-specification-that-hudson-supports

Introduces an `xmlbuilder` library.

Output looks like so when ran against `auditjs`:

```
<?xml version="1.0"?>
<testsuite tests="142" timestamp="2020-01-23T16:05:01.503Z" failures="1">
  <testcase classname="pkg:npm/%40cyclonedx/bom@1.0.4" name="pkg:npm/%40cyclonedx/bom@1.0.4"/>
  <testcase classname="pkg:npm/parse-packagejson-name@1.0.1" name="pkg:npm/parse-packagejson-name@1.0.1"/>
  <testcase classname="pkg:npm/prettify-xml@1.2.0" name="pkg:npm/prettify-xml@1.2.0"/>
  <testcase classname="pkg:npm/read-installed@4.0.3" name="pkg:npm/read-installed@4.0.3"/>
  <testcase classname="pkg:npm/debuglog@1.0.1" name="pkg:npm/debuglog@1.0.1"/>
  <testcase classname="pkg:npm/read-package-json@2.1.1" name="pkg:npm/read-package-json@2.1.1"/>
  <testcase classname="pkg:npm/glob@7.1.3" name="pkg:npm/glob@7.1.3"/>
  <testcase classname="pkg:npm/fs.realpath@1.0.0" name="pkg:npm/fs.realpath@1.0.0"/>
  <testcase classname="pkg:npm/inflight@1.0.6" name="pkg:npm/inflight@1.0.6"/>
  <testcase classname="pkg:npm/once@1.4.0" name="pkg:npm/once@1.4.0"/>
  <testcase classname="pkg:npm/wrappy@1.0.2" name="pkg:npm/wrappy@1.0.2"/>
  <testcase classname="pkg:npm/inherits@2.0.4" name="pkg:npm/inherits@2.0.4"/>
  <testcase classname="pkg:npm/minimatch@3.0.4" name="pkg:npm/minimatch@3.0.4"/>
  <testcase classname="pkg:npm/brace-expansion@1.1.11" name="pkg:npm/brace-expansion@1.1.11"/>
  <testcase classname="pkg:npm/balanced-match@1.0.0" name="pkg:npm/balanced-match@1.0.0"/>
  <testcase classname="pkg:npm/concat-map@0.0.1" name="pkg:npm/concat-map@0.0.1"/>
  <testcase classname="pkg:npm/path-is-absolute@1.0.1" name="pkg:npm/path-is-absolute@1.0.1"/>
  <testcase classname="pkg:npm/json-parse-better-errors@1.0.2" name="pkg:npm/json-parse-better-errors@1.0.2"/>
  <testcase classname="pkg:npm/normalize-package-data@2.5.0" name="pkg:npm/normalize-package-data@2.5.0"/>
  <testcase classname="pkg:npm/hosted-git-info@2.8.5" name="pkg:npm/hosted-git-info@2.8.5"/>
  <testcase classname="pkg:npm/resolve@1.14.1" name="pkg:npm/resolve@1.14.1"/>
  <testcase classname="pkg:npm/path-parse@1.0.6" name="pkg:npm/path-parse@1.0.6"/>
  <testcase classname="pkg:npm/semver@5.7.1" name="pkg:npm/semver@5.7.1"/>
  <testcase classname="pkg:npm/validate-npm-package-license@3.0.4" name="pkg:npm/validate-npm-package-license@3.0.4"/>
  <testcase classname="pkg:npm/spdx-correct@3.1.0" name="pkg:npm/spdx-correct@3.1.0"/>
  <testcase classname="pkg:npm/spdx-expression-parse@3.0.0" name="pkg:npm/spdx-expression-parse@3.0.0"/>
  <testcase classname="pkg:npm/spdx-exceptions@2.2.0" name="pkg:npm/spdx-exceptions@2.2.0"/>
  <testcase classname="pkg:npm/spdx-license-ids@3.0.5" name="pkg:npm/spdx-license-ids@3.0.5"/>
  <testcase classname="pkg:npm/npm-normalize-package-bin@1.0.1" name="pkg:npm/npm-normalize-package-bin@1.0.1"/>
  <testcase classname="pkg:npm/readdir-scoped-modules@1.1.0" name="pkg:npm/readdir-scoped-modules@1.1.0"/>
  <testcase classname="pkg:npm/dezalgo@1.0.3" name="pkg:npm/dezalgo@1.0.3"/>
  <testcase classname="pkg:npm/asap@2.0.6" name="pkg:npm/asap@2.0.6"/>
  <testcase classname="pkg:npm/graceful-fs@4.2.3" name="pkg:npm/graceful-fs@4.2.3"/>
  <testcase classname="pkg:npm/slide@1.1.6" name="pkg:npm/slide@1.1.6"/>
  <testcase classname="pkg:npm/util-extend@1.0.3" name="pkg:npm/util-extend@1.0.3"/>
  <testcase classname="pkg:npm/ssri@6.0.1" name="pkg:npm/ssri@6.0.1"/>
  <testcase classname="pkg:npm/figgy-pudding@3.5.1" name="pkg:npm/figgy-pudding@3.5.1"/>
  <testcase classname="pkg:npm/uuid@3.3.3" name="pkg:npm/uuid@3.3.3"/>
  <testcase classname="pkg:npm/%40types/figlet@1.2.0" name="pkg:npm/%40types/figlet@1.2.0"/>
  <testcase classname="pkg:npm/%40types/js-yaml@3.12.1" name="pkg:npm/%40types/js-yaml@3.12.1"/>
  <testcase classname="pkg:npm/%40types/node@12.12.17" name="pkg:npm/%40types/node@12.12.17"/>
  <testcase classname="pkg:npm/%40types/node-fetch@2.5.4" name="pkg:npm/%40types/node-fetch@2.5.4"/>
  <testcase classname="pkg:npm/%40types/node-persist@3.0.0" name="pkg:npm/%40types/node-persist@3.0.0"/>
  <testcase classname="pkg:npm/%40types/yargs@13.0.3" name="pkg:npm/%40types/yargs@13.0.3"/>
  <testcase classname="pkg:npm/%40types/yargs-parser@13.1.0" name="pkg:npm/%40types/yargs-parser@13.1.0"/>
  <testcase classname="pkg:npm/%40types/yarnpkg__lockfile@1.1.3" name="pkg:npm/%40types/yarnpkg__lockfile@1.1.3"/>
  <testcase classname="pkg:npm/%40yarnpkg/lockfile@1.1.0" name="pkg:npm/%40yarnpkg/lockfile@1.1.0"/>
  <testcase classname="pkg:npm/chalk@3.0.0" name="pkg:npm/chalk@3.0.0"/>
  <testcase classname="pkg:npm/ansi-styles@4.2.0" name="pkg:npm/ansi-styles@4.2.0"/>
  <testcase classname="pkg:npm/%40types/color-name@1.1.1" name="pkg:npm/%40types/color-name@1.1.1"/>
  <testcase classname="pkg:npm/color-convert@2.0.1" name="pkg:npm/color-convert@2.0.1"/>
  <testcase classname="pkg:npm/color-name@1.1.4" name="pkg:npm/color-name@1.1.4"/>
  <testcase classname="pkg:npm/supports-color@7.1.0" name="pkg:npm/supports-color@7.1.0"/>
  <testcase classname="pkg:npm/has-flag@4.0.0" name="pkg:npm/has-flag@4.0.0"/>
  <testcase classname="pkg:npm/colors@1.4.0" name="pkg:npm/colors@1.4.0"/>
  <testcase classname="pkg:npm/figlet@1.2.4" name="pkg:npm/figlet@1.2.4"/>
  <testcase classname="pkg:npm/js-yaml@3.13.1" name="pkg:npm/js-yaml@3.13.1"/>
  <testcase classname="pkg:npm/argparse@1.0.10" name="pkg:npm/argparse@1.0.10"/>
  <testcase classname="pkg:npm/sprintf-js@1.0.3" name="pkg:npm/sprintf-js@1.0.3"/>
  <testcase classname="pkg:npm/esprima@4.0.1" name="pkg:npm/esprima@4.0.1"/>
  <testcase classname="pkg:npm/lodash@4.17.5" name="pkg:npm/lodash@4.17.5">
    <failure type="CWE-506: Embedded Malicious Code">Vulnerability Title: CWE-506: Embedded Malicious Code
ID: a86c2790-8c02-4fee-8d77-3366312f926b
Description: The application contains code that appears to be malicious in nature.
CVSS Score: 9.6
CVSS Vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
CVE: undefined
Reference: https://ossindex.sonatype.org/vuln/a86c2790-8c02-4fee-8d77-3366312f926b
</failure>
    <failure type="[NPMJS]Prototype Pollution">Vulnerability Title: [NPMJS]Prototype Pollution
ID: 78a61524-80c5-4371-b6d1-6b32af349043
Description: The component 'Lodash' is vulnerable.

null

[For all versions before 4.17.11.]
CVSS Score: 8.8
CVSS Vector: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
CVE: undefined
Reference: https://ossindex.sonatype.org/vuln/78a61524-80c5-4371-b6d1-6b32af349043
</failure>
  </testcase>
  <testcase classname="pkg:npm/node-fetch@2.6.0" name="pkg:npm/node-fetch@2.6.0"/>
  <testcase classname="pkg:npm/node-persist@3.0.5" name="pkg:npm/node-persist@3.0.5"/>
  <testcase classname="pkg:npm/mkdirp@0.5.1" name="pkg:npm/mkdirp@0.5.1"/>
  <testcase classname="pkg:npm/minimist@0.0.8" name="pkg:npm/minimist@0.0.8"/>
  <testcase classname="pkg:npm/ora@4.0.3" name="pkg:npm/ora@4.0.3"/>
  <testcase classname="pkg:npm/cli-cursor@3.1.0" name="pkg:npm/cli-cursor@3.1.0"/>
  <testcase classname="pkg:npm/restore-cursor@3.1.0" name="pkg:npm/restore-cursor@3.1.0"/>
  <testcase classname="pkg:npm/onetime@5.1.0" name="pkg:npm/onetime@5.1.0"/>
  <testcase classname="pkg:npm/mimic-fn@2.1.0" name="pkg:npm/mimic-fn@2.1.0"/>
  <testcase classname="pkg:npm/signal-exit@3.0.2" name="pkg:npm/signal-exit@3.0.2"/>
  <testcase classname="pkg:npm/cli-spinners@2.2.0" name="pkg:npm/cli-spinners@2.2.0"/>
  <testcase classname="pkg:npm/is-interactive@1.0.0" name="pkg:npm/is-interactive@1.0.0"/>
  <testcase classname="pkg:npm/log-symbols@3.0.0" name="pkg:npm/log-symbols@3.0.0"/>
  <testcase classname="pkg:npm/chalk@2.4.2" name="pkg:npm/chalk@2.4.2"/>
  <testcase classname="pkg:npm/ansi-styles@3.2.1" name="pkg:npm/ansi-styles@3.2.1"/>
  <testcase classname="pkg:npm/color-convert@1.9.3" name="pkg:npm/color-convert@1.9.3"/>
  <testcase classname="pkg:npm/color-name@1.1.3" name="pkg:npm/color-name@1.1.3"/>
  <testcase classname="pkg:npm/escape-string-regexp@1.0.5" name="pkg:npm/escape-string-regexp@1.0.5"/>
  <testcase classname="pkg:npm/supports-color@5.5.0" name="pkg:npm/supports-color@5.5.0"/>
  <testcase classname="pkg:npm/has-flag@3.0.0" name="pkg:npm/has-flag@3.0.0"/>
  <testcase classname="pkg:npm/mute-stream@0.0.8" name="pkg:npm/mute-stream@0.0.8"/>
  <testcase classname="pkg:npm/strip-ansi@6.0.0" name="pkg:npm/strip-ansi@6.0.0"/>
  <testcase classname="pkg:npm/ansi-regex@5.0.0" name="pkg:npm/ansi-regex@5.0.0"/>
  <testcase classname="pkg:npm/wcwidth@1.0.1" name="pkg:npm/wcwidth@1.0.1"/>
  <testcase classname="pkg:npm/defaults@1.0.3" name="pkg:npm/defaults@1.0.3"/>
  <testcase classname="pkg:npm/clone@1.0.4" name="pkg:npm/clone@1.0.4"/>
  <testcase classname="pkg:npm/winston@3.2.1" name="pkg:npm/winston@3.2.1"/>
  <testcase classname="pkg:npm/async@2.6.3" name="pkg:npm/async@2.6.3"/>
  <testcase classname="pkg:npm/lodash@4.17.15" name="pkg:npm/lodash@4.17.15"/>
  <testcase classname="pkg:npm/diagnostics@1.1.1" name="pkg:npm/diagnostics@1.1.1"/>
  <testcase classname="pkg:npm/colorspace@1.1.2" name="pkg:npm/colorspace@1.1.2"/>
  <testcase classname="pkg:npm/color@3.0.0" name="pkg:npm/color@3.0.0"/>
  <testcase classname="pkg:npm/color-string@1.5.3" name="pkg:npm/color-string@1.5.3"/>
  <testcase classname="pkg:npm/simple-swizzle@0.2.2" name="pkg:npm/simple-swizzle@0.2.2"/>
  <testcase classname="pkg:npm/is-arrayish@0.3.2" name="pkg:npm/is-arrayish@0.3.2"/>
  <testcase classname="pkg:npm/text-hex@1.0.0" name="pkg:npm/text-hex@1.0.0"/>
  <testcase classname="pkg:npm/enabled@1.0.2" name="pkg:npm/enabled@1.0.2"/>
  <testcase classname="pkg:npm/env-variable@0.0.5" name="pkg:npm/env-variable@0.0.5"/>
  <testcase classname="pkg:npm/kuler@1.0.1" name="pkg:npm/kuler@1.0.1"/>
  <testcase classname="pkg:npm/colornames@1.1.1" name="pkg:npm/colornames@1.1.1"/>
  <testcase classname="pkg:npm/is-stream@1.1.0" name="pkg:npm/is-stream@1.1.0"/>
  <testcase classname="pkg:npm/logform@2.1.2" name="pkg:npm/logform@2.1.2"/>
  <testcase classname="pkg:npm/fast-safe-stringify@2.0.7" name="pkg:npm/fast-safe-stringify@2.0.7"/>
  <testcase classname="pkg:npm/fecha@2.3.3" name="pkg:npm/fecha@2.3.3"/>
  <testcase classname="pkg:npm/ms@2.1.2" name="pkg:npm/ms@2.1.2"/>
  <testcase classname="pkg:npm/triple-beam@1.3.0" name="pkg:npm/triple-beam@1.3.0"/>
  <testcase classname="pkg:npm/one-time@0.0.4" name="pkg:npm/one-time@0.0.4"/>
  <testcase classname="pkg:npm/readable-stream@3.4.0" name="pkg:npm/readable-stream@3.4.0"/>
  <testcase classname="pkg:npm/string_decoder@1.3.0" name="pkg:npm/string_decoder@1.3.0"/>
  <testcase classname="pkg:npm/safe-buffer@5.2.0" name="pkg:npm/safe-buffer@5.2.0"/>
  <testcase classname="pkg:npm/util-deprecate@1.0.2" name="pkg:npm/util-deprecate@1.0.2"/>
  <testcase classname="pkg:npm/stack-trace@0.0.10" name="pkg:npm/stack-trace@0.0.10"/>
  <testcase classname="pkg:npm/winston-transport@4.3.0" name="pkg:npm/winston-transport@4.3.0"/>
  <testcase classname="pkg:npm/readable-stream@2.3.6" name="pkg:npm/readable-stream@2.3.6"/>
  <testcase classname="pkg:npm/core-util-is@1.0.2" name="pkg:npm/core-util-is@1.0.2"/>
  <testcase classname="pkg:npm/isarray@1.0.0" name="pkg:npm/isarray@1.0.0"/>
  <testcase classname="pkg:npm/process-nextick-args@2.0.1" name="pkg:npm/process-nextick-args@2.0.1"/>
  <testcase classname="pkg:npm/safe-buffer@5.1.2" name="pkg:npm/safe-buffer@5.1.2"/>
  <testcase classname="pkg:npm/string_decoder@1.1.1" name="pkg:npm/string_decoder@1.1.1"/>
  <testcase classname="pkg:npm/xmlbuilder@13.0.2" name="pkg:npm/xmlbuilder@13.0.2"/>
  <testcase classname="pkg:npm/yargs@15.0.2" name="pkg:npm/yargs@15.0.2"/>
  <testcase classname="pkg:npm/cliui@6.0.0" name="pkg:npm/cliui@6.0.0"/>
  <testcase classname="pkg:npm/string-width@4.2.0" name="pkg:npm/string-width@4.2.0"/>
  <testcase classname="pkg:npm/emoji-regex@8.0.0" name="pkg:npm/emoji-regex@8.0.0"/>
  <testcase classname="pkg:npm/is-fullwidth-code-point@3.0.0" name="pkg:npm/is-fullwidth-code-point@3.0.0"/>
  <testcase classname="pkg:npm/wrap-ansi@6.2.0" name="pkg:npm/wrap-ansi@6.2.0"/>
  <testcase classname="pkg:npm/decamelize@1.2.0" name="pkg:npm/decamelize@1.2.0"/>
  <testcase classname="pkg:npm/find-up@4.1.0" name="pkg:npm/find-up@4.1.0"/>
  <testcase classname="pkg:npm/locate-path@5.0.0" name="pkg:npm/locate-path@5.0.0"/>
  <testcase classname="pkg:npm/p-locate@4.1.0" name="pkg:npm/p-locate@4.1.0"/>
  <testcase classname="pkg:npm/p-limit@2.2.1" name="pkg:npm/p-limit@2.2.1"/>
  <testcase classname="pkg:npm/p-try@2.2.0" name="pkg:npm/p-try@2.2.0"/>
  <testcase classname="pkg:npm/path-exists@4.0.0" name="pkg:npm/path-exists@4.0.0"/>
  <testcase classname="pkg:npm/get-caller-file@2.0.5" name="pkg:npm/get-caller-file@2.0.5"/>
  <testcase classname="pkg:npm/require-directory@2.1.1" name="pkg:npm/require-directory@2.1.1"/>
  <testcase classname="pkg:npm/require-main-filename@2.0.0" name="pkg:npm/require-main-filename@2.0.0"/>
  <testcase classname="pkg:npm/set-blocking@2.0.0" name="pkg:npm/set-blocking@2.0.0"/>
  <testcase classname="pkg:npm/which-module@2.0.0" name="pkg:npm/which-module@2.0.0"/>
  <testcase classname="pkg:npm/y18n@4.0.0" name="pkg:npm/y18n@4.0.0"/>
  <testcase classname="pkg:npm/yargs-parser@16.1.0" name="pkg:npm/yargs-parser@16.1.0"/>
  <testcase classname="pkg:npm/camelcase@5.3.1" name="pkg:npm/camelcase@5.3.1"/>
</testsuite>
```

Right now I've created a testcase for every dependency, and version via the purl, and then added failures with the results of what failed (title and description for now). This will show as a lot of testcases (dependent on your project), and show vulnerable deps as failed test cases.

To test: `auditjs ossi --xml > file.xml` and that file.xml could be saved as testresults in Jenkins

`auditjs` output to XML worked slightly differently, I think I dig this way more? Would love to hear others feedback.

Fixes #115 

CC @ajurgenson55 @allenhsieh @ken-duck 