### PR TITLE
Fix: explicitly import URL constructor so auditjs will work on node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "bin/**/*"
   ],
   "preferGlobal": true,
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "scripts": {
     "test": "mocha -r ts-node/register src/**/*.spec.ts",
     "build": "tsc -p tsconfig.json",

--- a/src/Services/IqRequestService.ts
+++ b/src/Services/IqRequestService.ts
@@ -16,6 +16,7 @@
 import fetch from 'node-fetch';
 import { RequestHelpers } from './RequestHelpers';
 import { logMessage, DEBUG } from '../Application/Logger/Logger';
+import { URL } from 'url';
 
 const APPLICATION_INTERNAL_ID_ENDPOINT = '/api/v2/applications?publicId=';
 


### PR DESCRIPTION
URL constructor is [not global on node 8 ](https://stackoverflow.com/a/45615942).

This PR changes 2 things:
1) explicitly import the URL constructor, thus auditjs works on node 8 
![image](https://user-images.githubusercontent.com/10136383/73017701-1a7dc580-3dd5-11ea-861e-b2badc68e63f.png)

2) adds an engine to the package.json

Should resolve #134 and the issue @Iletee was seeing.