### PR TITLE
Add example section for CI CD and include the npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ TBD
 We've provided an example repo with a working CircleCI config on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-in-circleci).
 
 #### TravisCI
-TBD
+
+We've provided an example repo with a working TravisCI config on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-in-travisci)
 
 #### GitHub Actions
 TBD

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ The format in these files is similar to:
 TBD
 
 #### CircleCI
-TBD
+
+We've provided an example repo with a working CircleCI config on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-in-circleci).
 
 #### TravisCI
 TBD

--- a/README.md
+++ b/README.md
@@ -121,10 +121,11 @@ We've provided an example repo with a working CircleCI config on a "fake" but re
 
 #### TravisCI
 
-We've provided an example repo with a working TravisCI config on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-in-travisci)
+We've provided an example repo with a working TravisCI config on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-in-travisci).
 
 #### GitHub Actions
-TBD
+
+We've provided an example repo with a working GitHub Action on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-with-github-actions).
 
 ### Usage As A NPM Script
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,48 @@ The format in these files is similar to:
   timestamp: '2019-12-22T20:09:33.447Z' }
 ```
 
+### Usage in CI
+
+#### Jenkins
+TBD
+
+#### CircleCI
+TBD
+
+#### TravisCI
+TBD
+
+#### GitHub Actions
+TBD
+
+### Usage As A NPM Script
+
+`auditjs` can be added as a devDependency to your project, and then an npm script can be added so you can leverage it in your npm scripts.
+
+You would install `auditjs` like so:
+
+```
+$ npm i auditjs -D
+```
+
+An example snippet from a `package.json`:
+
+```
+  },
+  "scripts": {
+    "test": "mocha -r ts-node/register src/**/*.spec.ts",
+    "build": "tsc -p tsconfig.json",
+    "build-dev": "tsc -p tsconfig.development.json",
+    "start": "node ./bin/index.js",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run test",
+    "scan": "auditjs ossi"
+  },
+  "keywords": [
+```
+
+Now that we've added a `scan` script, you can run `npm run scan` and your project will invoke `auditjs` and scan your dependencies. This can be handy for local work, or for if you want to run `auditjs` in CI/CD without installing it globally.
+
 ## Config file
 
 Config is now set via the command line, you can do so by running `auditjs config`. You will be prompted if you'd like to set Nexus IQ Server config or Sonatype OSS Index config. Reasonable defaults are provided for Sonatype Nexus IQ Server that will work for an out of the box install. It is STRONGLY suggested that you do not save your password in config (although it will work), but rather use a token from OSS Index or Nexus IQ Server.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ An example snippet from a `package.json`:
 
 Now that we've added a `scan` script, you can run `npm run scan` and your project will invoke `auditjs` and scan your dependencies. This can be handy for local work, or for if you want to run `auditjs` in CI/CD without installing it globally.
 
-Note: these reference implementation are applicable to running an IQ scan as well.  The caveat is that the config for the IQ url and auth needs to either be in the home directory of the user running the job, or stored as (preferably secret) environmental variables.  
+Note: these reference implementations are applicable to running an IQ scan as well.  The caveat is that the config for the IQ url and auth needs to either be in the home directory of the user running the job, or stored as (preferably secret) environmental variables.  
 
 ## Config file
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ An example snippet from a `package.json`:
 
 Now that we've added a `scan` script, you can run `npm run scan` and your project will invoke `auditjs` and scan your dependencies. This can be handy for local work, or for if you want to run `auditjs` in CI/CD without installing it globally.
 
+Note: these reference implementation are applicable to running an IQ scan as well.  The caveat is that the config for the IQ url and auth needs to either be in the home directory of the user running the job, or stored as (preferably secret) environmental variables.  
+
 ## Config file
 
 Config is now set via the command line, you can do so by running `auditjs config`. You will be prompted if you'd like to set Nexus IQ Server config or Sonatype OSS Index config. Reasonable defaults are provided for Sonatype Nexus IQ Server that will work for an out of the box install. It is STRONGLY suggested that you do not save your password in config (although it will work), but rather use a token from OSS Index or Nexus IQ Server.


### PR DESCRIPTION
This adds in some quick lil spots for CI/CD examples, and then also a fleshed out section for how to use `auditjs` as an npm script.

Related to #121 #124 #120 #123 

Fixes #120 #121 #123 