### PR TITLE
Fix bug where if @types/lib and lib exist and have same version, only one showed up

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "chalk": "^3.0.0",
     "colors": "^1.3.1",
     "figlet": "^1.2.4",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "3.13.1",
     "node-fetch": "^2.6.0",
     "node-persist": "^3.0.5",
     "ora": "^4.0.3",

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -55,6 +55,7 @@ export class NpmList implements Muncher {
     let data = await this.getReadInstalledResults();
 
     this.recurseObjectTree(data, this.depsArray, true);
+    console.log(this.depsArray);
 
     return this.depsArray;
   }
@@ -119,7 +120,7 @@ export class NpmList implements Muncher {
     }
     else if (pkg.name) {
       if (list.find((x) => { 
-        return (x.name == pkg.name && x.version == pkg.version)
+        return (x.name == pkg.name && x.version == pkg.version && x.group == '')
         })
       ) { 
         return false 
@@ -133,7 +134,6 @@ export class NpmList implements Muncher {
   private toPurlObjTree(objectTree: any): string {
     if (objectTree.name && objectTree.name.includes('/')) {
       let name = objectTree.name.split('/');
-
       return this.toPurl(name[1], objectTree.version, name[0]);
     }
     else if (objectTree.name) {

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -55,7 +55,6 @@ export class NpmList implements Muncher {
     let data = await this.getReadInstalledResults();
 
     this.recurseObjectTree(data, this.depsArray, true);
-    console.log(this.depsArray);
 
     return this.depsArray;
   }


### PR DESCRIPTION
This was manifesting with `auditjs` itself, masking that we were using `js-yaml`, which is wildly vulnerable prior to the version we use :)

To test this:

- set @types/js-yaml and js-yaml to version 3.12.1 in package.json, preferably strict versions for both (aka `"3.12.1"`, not `"^3.12.1"`)

Try running auditjs without this branch and you'll see likely 140 results, and js-yaml itself will not be one of them. Then try running this branch with that case, you should see 141 results, and probs some vuln info.