### PR TITLE
fix: Add ability to clear cache from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Options:
   --json, -j       Set output to JSON                                  [boolean]
   --xml, -x        Set output to JUnit XML format                      [boolean]
   --whitelist, -w  Set path to whitelist file                           [string]
-  --clear          Clears cache location if it has been set in config
+  --clear          Clears cache location if it has been set in config  [boolean]
 ```
 
 ### Nexus IQ Server Usage

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ auditjs [command]
 Commands:
   auditjs iq [options]    Audit this application using Nexus IQ Server
   auditjs config          Set config for OSS Index or Nexus IQ Server
+  auditjs clear           Clear the cache if a location has been set in config
   auditjs ossi [options]  Audit this application using Sonatype OSS Index
 
 Options:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ auditjs [command]
 Commands:
   auditjs iq [options]    Audit this application using Nexus IQ Server
   auditjs config          Set config for OSS Index or Nexus IQ Server
-  auditjs clear           Clear the cache if a location has been set in config
   auditjs ossi [options]  Audit this application using Sonatype OSS Index
 
 Options:
@@ -60,6 +59,7 @@ Options:
   --json, -j       Set output to JSON                                  [boolean]
   --xml, -x        Set output to JUnit XML format                      [boolean]
   --whitelist, -w  Set path to whitelist file                           [string]
+  --clear          Clears cache location if it has been set in config
 ```
 
 ### Nexus IQ Server Usage

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -46,13 +46,13 @@ export class OssIndexServerConfig extends Config {
     return this.cacheLocation;
   }
 
-  public clearCache(): boolean {
+  public async clearCache(): Promise<void> {
     if (this.cacheLocation) {
-      storage.init({ dir: this.cacheLocation });
-      storage.clear();
-      return true;
+      await storage.init({ dir: this.cacheLocation });
+      await storage.clear();
+    } else {
+      throw new Error('There was an error clearing the Cache, did you remember to set the location in config?')
     }
-    return false;
   }
 
   public getConfigFromFile(

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -47,11 +47,15 @@ export class OssIndexServerConfig extends Config {
   }
 
   public async clearCache(): Promise<void> {
-    if (this.cacheLocation) {
-      await storage.init({ dir: this.cacheLocation });
-      return await storage.clear();
+    try {
+      if (this.exists()) {
+        await storage.init({ dir: this.cacheLocation });
+        return await storage.clear();
+      }
     }
-    throw new Error('There was an error clearing the Cache, did you remember to set the location in config?')
+    catch {
+      throw new Error('There was an error clearing the Cache, did you remember to set the location in config? Clear will only clear the location set in config')
+    }
   }
 
   public getConfigFromFile(

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -47,14 +47,13 @@ export class OssIndexServerConfig extends Config {
   }
 
   public async clearCache(): Promise<void> {
-    try {
-      if (this.exists()) {
-        await storage.init({ dir: this.cacheLocation });
-        return await storage.clear();
+    if (this.exists()) {
+      await storage.init({ dir: this.cacheLocation });
+      try {
+        await storage.clear();
+      } catch (error) {
+        return error;
       }
-    }
-    catch {
-      throw new Error('There was an error clearing the Cache, did you remember to set the location in config? Clear will only clear the location set in config')
     }
   }
 

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -51,16 +51,13 @@ export class OssIndexServerConfig extends Config {
       try {      
         await storage.init({ dir: this.cacheLocation });
         await storage.clear();
-        this.logger.debug("Cache cleared", {cacheLocation: this.cacheLocation});
         return true;
       }
       // It's likely an error would only ever occur if there was a permission based issue, so log it and move on
       catch (error) {
-        this.logger.error(error, {cacheLocation: this.cacheLocation});
         return false;
       }
     }
-    this.logger.debug("Config did not exist, exiting clear cache function");
     return false;
   }
 

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -47,19 +47,17 @@ export class OssIndexServerConfig extends Config {
   }
 
   public async clearCache(): Promise<boolean> {
-    if (this.exists()) {
-      try {      
-        await storage.init({ dir: this.cacheLocation });
-        await storage.clear();
-        return true;
-      }
-      // It's likely an error would only ever occur if there was a permission based issue, so log it and move on
-      catch (error) {
-        return false;
-      }
+    try {      
+      await storage.init({ dir: this.cacheLocation });
+      await storage.clear();
+      return true;
     }
-    return false;
+    // It's likely an error would only ever occur if there was a permission based issue, so log it and move on
+    catch (error) {
+      return false;
+    }
   }
+
 
   public getConfigFromFile(
     saveLocation: string = this.getConfigLocation()

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -48,11 +48,13 @@ export class OssIndexServerConfig extends Config {
 
   public async clearCache(): Promise<void> {
     if (this.exists()) {
-      await storage.init({ dir: this.cacheLocation });
-      try {
+      try {      
+        await storage.init({ dir: this.cacheLocation });
         await storage.clear();
-      } catch (error) {
-        return error;
+        return;
+      }
+      catch (error) {
+        throw new Error(error);
       }
     }
   }

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -49,10 +49,9 @@ export class OssIndexServerConfig extends Config {
   public async clearCache(): Promise<void> {
     if (this.cacheLocation) {
       await storage.init({ dir: this.cacheLocation });
-      await storage.clear();
-    } else {
-      throw new Error('There was an error clearing the Cache, did you remember to set the location in config?')
+      return await storage.clear();
     }
+    throw new Error('There was an error clearing the Cache, did you remember to set the location in config?')
   }
 
   public getConfigFromFile(

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -54,10 +54,10 @@ export class OssIndexServerConfig extends Config {
     }
     // It's likely an error would only ever occur if there was a permission based issue, so log it and move on
     catch (error) {
+      console.log(error);
       return false;
     }
   }
-
 
   public getConfigFromFile(
     saveLocation: string = this.getConfigLocation()

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -46,17 +46,22 @@ export class OssIndexServerConfig extends Config {
     return this.cacheLocation;
   }
 
-  public async clearCache(): Promise<void> {
+  public async clearCache(): Promise<boolean> {
     if (this.exists()) {
       try {      
         await storage.init({ dir: this.cacheLocation });
         await storage.clear();
-        return;
+        this.logger.debug("Cache cleared", {cacheLocation: this.cacheLocation});
+        return true;
       }
+      // It's likely an error would only ever occur if there was a permission based issue, so log it and move on
       catch (error) {
-        throw new Error(error);
+        this.logger.error(error, {cacheLocation: this.cacheLocation});
+        return false;
       }
     }
+    this.logger.debug("Config did not exist, exiting clear cache function");
+    return false;
   }
 
   public getConfigFromFile(

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -18,6 +18,7 @@ import { readFileSync } from "fs";
 import { getAppLogger } from "../Application/Logger/Logger";
 import { Logger } from "winston";
 import { safeLoad } from 'js-yaml';
+import storage from 'node-persist';
 
 export class OssIndexServerConfig extends Config {
 
@@ -43,6 +44,15 @@ export class OssIndexServerConfig extends Config {
 
   public getCacheLocation(): string {
     return this.cacheLocation;
+  }
+
+  public clearCache(): boolean {
+    if (this.cacheLocation) {
+      storage.init({ dir: this.cacheLocation });
+      storage.clear();
+      return true;
+    }
+    return false;
   }
 
   public getConfigFromFile(

--- a/src/Services/OssIndexRequestService.ts
+++ b/src/Services/OssIndexRequestService.ts
@@ -129,7 +129,7 @@ export class OssIndexRequestService {
    * @returns a {@link Promise} of all Responses
   */
   public async callOSSIndexOrGetFromCache(data: Coordinates[], format: string = "npm"): Promise<any> {
-    await NodePersist.init({ dir: this.cacheLocation, ttl: TWELVE_HOURS});
+    await NodePersist.init({ dir: this.cacheLocation, ttl: TWELVE_HOURS });
     let responses = new Array();
     // console.debug(`Purls received, total purls before chunk: ${data.length}`);
     let results = await this.checkIfResultsAreInCache(data, format);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { Application } from './Application/Application';
 import { AppConfig } from './Config/AppConfig';
 import { OssIndexServerConfig } from './Config/OssIndexServerConfig';
 import { ossIndexObject } from './Tests/TestHelper';
-import { createAppLogger } from './Application/Logger/Logger';
+import { createAppLogger, setConsoleTransportLevel, DEBUG } from './Application/Logger/Logger';
 
 // TODO: Flesh out the remaining set of args that NEED to be moved over, look at them with a fine toothed comb and lots of skepticism
 const normalizeHostAddress = (address: string) => {
@@ -170,6 +170,7 @@ if (argv) {
     let config = new OssIndexServerConfig();
     config.getConfigFromFile();
     createAppLogger();
+    setConsoleTransportLevel(DEBUG);
 
     console.log('Cache location:', config.getCacheLocation());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ if (argv) {
         console.log(`The cache at ${config.getCacheLocation()} has been cleared`)
       })
       .catch((e) => {
-        throw new Error(e)
+        console.log(e);
       })
   } else {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,14 +161,19 @@ if (argv) {
       });
   } else if (argv.clear) {
     let config = new OssIndexServerConfig();
-    config.getConfigFromFile();
+    if (config.exists()) {
+      config.getConfigFromFile();
 
-    console.log('Cache location:', config.getCacheLocation());
+      console.log('Cache location:', config.getCacheLocation());
 
-    config.clearCache()
-      .then((success) => {
-        (success) ? (console.log("Cache cleared"), process.exit(0)) : console.log('There was an issue clearing the cache, does a Config exist? Did you make sure to set the location of the cache?'), process.exit(1);
-      });
+      config.clearCache()
+        .then((success) => {
+          (success) ? (console.log("Cache cleared"), process.exit(0)) : process.exit(1);
+        });
+    }
+    else {
+      console.error("Attempted to clear cache but no config file present, run `auditjs config` to set a cache location.");
+    }
   } else if (argv._[0] == 'iq' || argv._[0] == 'ossi') {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,6 @@ if (argv) {
   } else if (argv.clear) {
     let config = new OssIndexServerConfig();
     config.getConfigFromFile();
-    createAppLogger();
-    setConsoleTransportLevel(DEBUG);
 
     console.log('Cache location:', config.getCacheLocation());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import yargs from 'yargs';
 import { Argv } from 'yargs';
 import { Application } from './Application/Application';
 import { AppConfig } from './Config/AppConfig';
+import { OssIndexServerConfig } from './Config/OssIndexServerConfig';
 
 // TODO: Flesh out the remaining set of args that NEED to be moved over, look at them with a fine toothed comb and lots of skepticism
 const normalizeHostAddress = (address: string) => {
@@ -92,6 +93,10 @@ let argv = yargs
     'Set config for OSS Index or Nexus IQ Server'
   )
   .command(
+    'clear',
+    'Clear the cache if a location is set in config'
+  )
+  .command(
     'ossi [options]', 
     "Audit this application using Sonatype OSS Index",
     (y: Argv) => {
@@ -158,6 +163,15 @@ if (argv) {
       .catch((e) => {
         throw new Error(e);
       });
+  } else if (argv._[0] === 'clear') {
+    let config = new OssIndexServerConfig();
+    config.getConfigFromFile();
+    console.log('Cache location:', config.getCacheLocation());
+    if (config.clearCache()) {
+      console.log(`The cache at ${config.getCacheLocation} has been cleared`)
+    } else {
+      throw new Error('There was a problem clearing cache, did you remember to set the location in your config file?')
+    }
   } else {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ if (argv) {
 
     config.clearCache()
       .then((success) => {
-        (success) ? process.exit(0) : process.exit(1);
+        (success) ? (console.log("Cache cleared"), process.exit(0)) : process.exit(1);
       });
   } else {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { Argv } from 'yargs';
 import { Application } from './Application/Application';
 import { AppConfig } from './Config/AppConfig';
 import { OssIndexServerConfig } from './Config/OssIndexServerConfig';
+import { ossIndexObject } from './Tests/TestHelper';
 
 // TODO: Flesh out the remaining set of args that NEED to be moved over, look at them with a fine toothed comb and lots of skepticism
 const normalizeHostAddress = (address: string) => {
@@ -174,14 +175,10 @@ if (argv) {
 
     console.log('Cache location:', config.getCacheLocation());
 
-    async () => {
-      try {
-        await config.clearCache();
-      }
-      catch (e) {
-        console.error(e);
-      }
-    } 
+    config.clearCache()
+      .then((success) => {
+        (success) ? process.exit(0) : process.exit(1);
+      });
   } else {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,10 +94,6 @@ let argv = yargs
     'Set config for OSS Index or Nexus IQ Server'
   )
   .command(
-    'clear',
-    'Clear the cache if a location is set in config'
-  )
-  .command(
     'ossi [options]', 
     "Audit this application using Sonatype OSS Index",
     (y: Argv) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ if (argv) {
           if (success) {
             console.log("Cache cleared");
           } else {
-            console.log('There was an error clearing the cache, the cache location must only contain auditjs cache files.');
+            console.log('There was an error clearing the cache, the cache location must only contain AuditJS cache files.');
           }
           process.exit(0);
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,11 +167,13 @@ if (argv) {
     let config = new OssIndexServerConfig();
     config.getConfigFromFile();
     console.log('Cache location:', config.getCacheLocation());
-    if (config.clearCache()) {
-      console.log(`The cache at ${config.getCacheLocation} has been cleared`)
-    } else {
-      throw new Error('There was a problem clearing cache, did you remember to set the location in your config file?')
-    }
+    config.clearCache()
+      .then(() => {
+        console.log(`The cache at ${config.getCacheLocation()} has been cleared`)
+      })
+      .catch((e) => {
+        throw new Error(e)
+      })
   } else {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,14 +171,17 @@ if (argv) {
   } else if (argv.clear) {
     let config = new OssIndexServerConfig();
     config.getConfigFromFile();
+
     console.log('Cache location:', config.getCacheLocation());
-    config.clearCache()
-      .then(() => {
-        console.log(`The cache at ${config.getCacheLocation()} has been cleared`)
-      })
-      .catch((e) => {
-        console.log(e);
-      })
+
+    async () => {
+      try {
+        await config.clearCache();
+      }
+      catch (e) {
+        console.error(e);
+      }
+    } 
   } else {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,11 @@ let argv = yargs
           type: 'string',
           description: 'Set path to whitelist file',
           demandOption: false
+        },
+        clear : {
+          description: 'Clears cache location if it has been set in config',
+          type: 'boolean',
+          demandOption: false
         }
       },
       )
@@ -163,7 +168,7 @@ if (argv) {
       .catch((e) => {
         throw new Error(e);
       });
-  } else if (argv._[0] === 'clear') {
+  } else if (argv.clear) {
     let config = new OssIndexServerConfig();
     config.getConfigFromFile();
     console.log('Cache location:', config.getCacheLocation());

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,10 +168,9 @@ if (argv) {
 
       config.clearCache()
         .then((success) => {
-          (success) ? (console.log("Cache cleared"), process.exit(0)) : process.exit(1);
+          (success) ? (console.log("Cache cleared"), process.exit(0)) : console.log('There was an error clearing the cache, the cache location must only contain auditjs cache files.'), process.exit(0);
         });
-    }
-    else {
+      } else {
       console.error("Attempted to clear cache but no config file present, run `auditjs config` to set a cache location.");
     }
   } else if (argv._[0] == 'iq' || argv._[0] == 'ossi') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ if (argv) {
 
     config.clearCache()
       .then((success) => {
-        (success) ? (console.log("Cache cleared"), process.exit(0)) : process.exit(1);
+        (success) ? (console.log("Cache cleared"), process.exit(0)) : console.log('There was an issue clearing the cache, does a Config exist? Did you make sure to set the location of the cache?'), process.exit(1);
       });
   } else if (argv._[0] == 'iq' || argv._[0] == 'ossi') {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,6 @@ import { Argv } from 'yargs';
 import { Application } from './Application/Application';
 import { AppConfig } from './Config/AppConfig';
 import { OssIndexServerConfig } from './Config/OssIndexServerConfig';
-import { ossIndexObject } from './Tests/TestHelper';
-import { createAppLogger, setConsoleTransportLevel, DEBUG } from './Application/Logger/Logger';
 
 // TODO: Flesh out the remaining set of args that NEED to be moved over, look at them with a fine toothed comb and lots of skepticism
 const normalizeHostAddress = (address: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,10 +170,11 @@ if (argv) {
         .then((success) => {
           if (success) {
             console.log("Cache cleared");
+            process.exit(0);
           } else {
             console.log('There was an error clearing the cache, the cache location must only contain AuditJS cache files.');
+            process.exit(1);
           }
-          process.exit(0);
         });
       } else {
       console.error("Attempted to clear cache but no config file present, run `auditjs config` to set a cache location.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,12 @@ if (argv) {
 
       config.clearCache()
         .then((success) => {
-          (success) ? (console.log("Cache cleared"), process.exit(0)) : console.log('There was an error clearing the cache, the cache location must only contain auditjs cache files.'), process.exit(0);
+          if (success) {
+            console.log("Cache cleared");
+          } else {
+            console.log('There was an error clearing the cache, the cache location must only contain auditjs cache files.');
+          }
+          process.exit(0);
         });
       } else {
       console.error("Attempted to clear cache but no config file present, run `auditjs config` to set a cache location.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { Application } from './Application/Application';
 import { AppConfig } from './Config/AppConfig';
 import { OssIndexServerConfig } from './Config/OssIndexServerConfig';
 import { ossIndexObject } from './Tests/TestHelper';
+import { createAppLogger } from './Application/Logger/Logger';
 
 // TODO: Flesh out the remaining set of args that NEED to be moved over, look at them with a fine toothed comb and lots of skepticism
 const normalizeHostAddress = (address: string) => {
@@ -168,6 +169,7 @@ if (argv) {
   } else if (argv.clear) {
     let config = new OssIndexServerConfig();
     config.getConfigFromFile();
+    createAppLogger();
 
     console.log('Cache location:', config.getCacheLocation());
 


### PR DESCRIPTION
Added the ability to clear the cache from the command line by running `npm run start ossi -- --clear` or `auditjs ossi -- clear`

This resolves #149 