### PR TITLE
fix: Logs are cleared with each run of AuditJS

### DIFF
--- a/src/Application/Logger/Logger.ts
+++ b/src/Application/Logger/Logger.ts
@@ -29,13 +29,15 @@ const transports = {
   ),
   file: new winston.transports.File(
     {
-      filename: path.join(homedir(), '.ossindex', '.audit-js.error.log'), 
+      filename: path.join(homedir(), '.ossindex', '.audit-js.error.log'),
+      options: { flags: 'w' }, 
       level: ERROR
     }
   ),
   combinedFile: new winston.transports.File(
     {
       filename: path.join(homedir(), '.ossindex', '.audit-js.combined.log'),
+      options: { flags: 'w' },
       level: DEBUG
     }
   )


### PR DESCRIPTION
Simple one liner that will cause logs to be overwritten each time auditjs is run, in order to decrease amount of space it takes up.

Ran a few times and can confirm the old logs are being overwritten:
![image](https://user-images.githubusercontent.com/10136383/74366317-a2c40a80-4d84-11ea-8efa-dae8e856ad09.png)

This resolves #150 (there is another way to do this so that logs are stored for X days -- but this requires another package)