### PR TITLE
bug: yarn project was not bringing back any dependencies

### DIFF
--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -74,7 +74,7 @@ export class NpmList implements Muncher {
 
   // recursive unit that traverses tree and terminates when object has no dependencies
   private recurseObjectTree(objectTree: any, list: Array<Coordinates>, isRootPkg: boolean = false) {
-    if (objectTree.extraneous) {
+    if (objectTree.extraneous && !this.devDependencies) {
       return;
     }
     if (!isRootPkg) {
@@ -86,21 +86,21 @@ export class NpmList implements Muncher {
       }
     }
     if (objectTree.dependencies) {
-      Object.keys(objectTree.dependencies)
+      let thing = Object.keys(objectTree.dependencies)
         .map((x) => objectTree.dependencies[x])
         .filter((x) => typeof(x) !== 'string')
-        .map((dep) => {
-          if (
-            this.toPurlObjTree(objectTree) == '' || 
-            list.find((x) => { 
-              return x.toPurl() == this.toPurlObjTree(objectTree) 
-              })
-            ) {
-            return; 
-          } else {
-            this.recurseObjectTree(dep, list, false);
-          }
-      });
+      
+      for (let dep of thing) {
+        if (
+          this.toPurlObjTree(dep) == '' || 
+          list.find((x) => { 
+            return x.toPurl() == this.toPurlObjTree(dep) 
+            })
+          ) {
+          break; 
+        }
+        this.recurseObjectTree(dep, list, false);
+      }
     }
     return;
   }

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -89,18 +89,17 @@ export class NpmList implements Muncher {
       let thing = Object.keys(objectTree.dependencies)
         .map((x) => objectTree.dependencies[x])
         .filter((x) => typeof(x) !== 'string')
-      
-      for (let dep of thing) {
-        if (
-          this.toPurlObjTree(dep) == '' || 
-          list.find((x) => { 
-            return x.toPurl() == this.toPurlObjTree(dep) 
-            })
-          ) {
-          break; 
-        }
-        this.recurseObjectTree(dep, list, false);
-      }
+        .map((dep) => {
+          if (
+            this.toPurlObjTree(dep) == '' || 
+            list.find((x) => { 
+              return x.toPurl() == this.toPurlObjTree(dep) 
+              })
+            ) {
+            return;
+          }
+          this.recurseObjectTree(dep, list, false);
+        });
     }
     return;
   }

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -86,7 +86,7 @@ export class NpmList implements Muncher {
       }
     }
     if (objectTree.dependencies) {
-      let thing = Object.keys(objectTree.dependencies)
+      Object.keys(objectTree.dependencies)
         .map((x) => objectTree.dependencies[x])
         .filter((x) => typeof(x) !== 'string')
         .map((dep) => {


### PR DESCRIPTION
This PR is related to trying to use `auditjs` on https://github.com/DCAFEngineering/dcaf_case_management/ and seeing it brought back no dependencies.

The tweaks I made are:

- I noticed that in this project that read-installed was marking libs that I thought should be included as prod deps as dev deps, so I've included another check in the recursive function where I also check if we want devDeps included (we were relying on read-installed itself, and it might be problematic with a yarn project, haven't full figured that out yet).
- Instead of passing the objectTree once I'm in the map, I pass the dep, as that should be more memory efficient

Whatever I did, ended up fixing `auditjs` for this project.