### PR TITLE
fix: Added section to README to mention Version 77+ of Nexus IQ needed for AuditJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Supports any project with package managers that install npm dependencies into a 
 
 <img src="https://github.com/sonatype-nexus-community/auditjs/blob/alpha/assets/images/auditjs.png?raw=true" width="640">
 
+## Requirement
+For users that are hoping to scan with Nexus IQ Server, Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server. 
+
 ## Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports any project with package managers that install npm dependencies into a 
 <img src="https://github.com/sonatype-nexus-community/auditjs/blob/alpha/assets/images/auditjs.png?raw=true" width="640">
 
 ## Requirement
-For users scanning with Nexus IQ Server, Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server. 
+For users wanting to use Nexus IQ Server as their data source for scanning, Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server. 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports any project with package managers that install npm dependencies into a 
 <img src="https://github.com/sonatype-nexus-community/auditjs/blob/alpha/assets/images/auditjs.png?raw=true" width="640">
 
 ## Requirement
-For users that are hoping to scan with Nexus IQ Server, Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server. 
+For users scanning with Nexus IQ Server, Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server. 
 
 ## Installation
 


### PR DESCRIPTION
Third-party REST scan API wasn't added until version 77 of Nexus IQ Server. Made this requirement explicit in the README. 

Resolves #157 