### PR TITLE
Show usage for any command we don't actually support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,10 +144,6 @@ let argv = yargs
   .argv;
 
 if (argv) {
-  if (argv._[0] == undefined) {
-    yargs.showHelp();
-    process.exit(0);
-  }
   if (argv._[0] == 'config') {
     let config = new AppConfig();
 
@@ -158,7 +154,8 @@ if (argv) {
       .catch((e) => {
         throw new Error(e);
       });
-  } else {
+  } 
+  else if (argv._[0] == 'iq' || argv._[0] == 'ossi') {
     let silence = (argv.json || argv.quiet || argv.xml) ? true : false;
     let artie = (argv.artie) ? true : false;
 
@@ -178,5 +175,8 @@ if (argv) {
     catch(error) {
       console.error(error.message);
     }
+  } else {
+    yargs.showHelp();
+    process.exit(0);
   }
 }


### PR DESCRIPTION
This PR reorgs things a bit so that if you do:

`auditjs thing`, you'll get shown usage
`auditjs clear`, you'll get shown usage
`auditjs ossi`, you'll get the application running
`auditjs iq` you'll get the application running
`auditjs config`, you'll get to set config

Basically any command we don't explicitly support, you'll get shown usage!

I believe this fixes #155 