### PR TITLE
fix: Sorting vulnerabilities (high to low) and change colors

### DIFF
--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -122,7 +122,7 @@ export class AuditOSSIndex {
     return vulnBlock;
   }
 
-  private getColorFromMaxScore(maxScore: number, defaultColor: string = 'darkblue'): string {
+  private getColorFromMaxScore(maxScore: number, defaultColor: string = 'chartreuse'): string {
     if (maxScore > 8) {
       defaultColor = 'red';
     }

--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -155,7 +155,7 @@ export class AuditOSSIndex {
 
     console.log(chalk.keyword(this.getColorFromMaxScore(maxScore)).bold(`[${i + 1}/${total}] - ${result.toAuditLog()}`));
     console.log();
-    result.vulnerabilities && printVuln(result.vulnerabilities);
+    result.vulnerabilities && printVuln(result.vulnerabilities.sort((x, y) => { return +y.cvssScore - +x.cvssScore; }));
   }
 
   private printLine(line: any) {


### PR DESCRIPTION
Will now sort vulnerabilities by CVSS score (high to low) in OSSI results, also changed colors so while they no longer match IQ Server, they are more logical (roughly: green = good, red = bad)