### PR TITLE
Explicitly mention can evaluate app permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Supports any project with package managers that install npm dependencies into a 
 
 <img src="https://github.com/sonatype-nexus-community/auditjs/blob/master/assets/images/auditjsnew.png?raw=true" width="640">
 
-## Requirement
+## Requirements
+For users wanting to use Nexus IQ Server as their data source for scanning:
+1)  Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server.
 
-For users wanting to use Nexus IQ Server as their data source for scanning, Version 77 or above must be installed. This is when the [Third-Party Scan REST API](https://help.sonatype.com/iqserver/automating/rest-apis/third-party-scan-rest-api---v2) was incorporated into Nexus IQ Server.
+2) The User performing the scan must have the permission "Can Evaluate Applications", this can be found in the Role Editor > *User* > Permissions > IQ
 
 ## Installation
 


### PR DESCRIPTION
This pull request makes the following changes:
* Explicitly mentions that "Can Evaluate Applications" permission must be enabled to perform an IQ scan and where to find the permission

It relates to the following issue #s:
* Fixes #168 

cc @kevinfauth 
