### PR TITLE
Suggest to run with dev flag if 0 dependencies are found

### DIFF
--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -36,7 +36,7 @@ export class AuditOSSIndex {
     console.log();
     console.group();
     this.printLine('Sonabot here, beep boop beep boop, here are your Sonatype OSS Index results:');
-    this.printLine(`Total dependencies audited: ${total}`);
+    this.suggestIncludeDevDeps(total);
     console.groupEnd();
     console.log();
 
@@ -170,6 +170,15 @@ export class AuditOSSIndex {
   private printLine(line: any): void {
     if (!this.quiet) {
       console.log(line);
+    }
+  }
+
+  private suggestIncludeDevDeps(total: number) {
+    this.printLine(`Total dependencies audited: ${total}`);
+    if (total == 0) {
+      this.printLine(
+        `We noticed you had 0 dependencies, we exclude devDependencies by default, try running with --dev if you want to include those as well`,
+      );
     }
   }
 }


### PR DESCRIPTION
For cases where a user has 0 dependencies found, it might be because they haven't included `devDependencies`. This PR suggests to them to run with `--dev` in that case. This is only for OSS Index at the moment, as we do not print in this manner for IQ.

This pull request makes the following changes:
* Modifies `AuditOSSIndex.ts` to suggest to a user to run with `--dev` if 0 dependencies are found

It relates to the following issue #s:
* Fixes #167 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
