### PR TITLE
Mention npx before npm global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,21 @@ For users wanting to use Nexus IQ Server as their data source for scanning:
 
 ## Installation
 
+You can use `auditjs` a number of ways:
+
+via npx (least permanent install)
+
+```
+npx auditjs@latest ossi
+```
+
+via global install (most permanent install)
+
 ```
 npm install -g auditjs
 ```
+
+We suggest you use it via `npx`, as global installs are generally frowned upon in the nodejs world.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
     "OSSIndex",
     "Artie",
     "Nexus",
-    "Sonatype"
+    "Sonatype",
+    "SCA",
+    "SBOM",
+    "Security",
+    "Advisories"
   ],
   "author": "Sonatype Community",
   "license": "Apache-2.0",


### PR DESCRIPTION
Based on some usability testing today, it's likely worth suggesting `npx` before we send people to `npm install -g`

This pull request makes the following changes:
* Small README change

It relates to the following issue #s:
* Fixes #176 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
