### PR TITLE
WIP but move to formatters

### DIFF
--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -41,8 +41,6 @@ export class AuditOSSIndex {
 
     this.formatter.printAuditResults(results);
 
-    let isVulnerable = getNumberOfVulnerablePackagesFromResults(results) > 0;
-
-    return isVulnerable;
+    return getNumberOfVulnerablePackagesFromResults(results) > 0;
   }
 }

--- a/src/Audit/Formatters/Formatter.ts
+++ b/src/Audit/Formatters/Formatter.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OssIndexServerResult } from '../../Types/OssIndexServerResult';
+
+export interface Formatter {
+  printAuditResults(list: Array<OssIndexServerResult>): void;
+}
+
+export const getNumberOfVulnerablePackagesFromResults = (results: Array<OssIndexServerResult>): number => {
+  return results.filter((x) => {
+    return x.vulnerabilities && x.vulnerabilities?.length > 0;
+  }).length;
+};

--- a/src/Audit/Formatters/JsonFormatter.ts
+++ b/src/Audit/Formatters/JsonFormatter.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Formatter } from './Formatter';
+import { OssIndexServerResult } from '../../Types/OssIndexServerResult';
+
+export class JsonFormatter implements Formatter {
+  public printAuditResults(list: Array<OssIndexServerResult>) {
+    console.log(JSON.stringify(list, null, 2));
+  }
+}

--- a/src/Audit/Formatters/TextFormatter.ts
+++ b/src/Audit/Formatters/TextFormatter.ts
@@ -14,8 +14,98 @@
  * limitations under the License.
  */
 import { Formatter } from './Formatter';
-import { OssIndexServerResult } from '../../Types/OssIndexServerResult';
+import { OssIndexServerResult, Vulnerability } from '../../Types/OssIndexServerResult';
+import chalk = require('chalk');
 
 export class TextFormatter implements Formatter {
-  public printAuditResults(list: Array<OssIndexServerResult>) {}
+  constructor(readonly quiet: boolean = false) {}
+
+  public printAuditResults(list: Array<OssIndexServerResult>) {
+    const total = list.length;
+    list = list.sort((a, b) => {
+      return a.coordinates < b.coordinates ? -1 : 1;
+    });
+
+    console.log();
+    console.group();
+    this.printLine('Sonabot here, beep boop beep boop, here are your Sonatype OSS Index results:');
+    this.suggestIncludeDevDeps(total);
+    console.groupEnd();
+    console.log();
+
+    this.printLine('-'.repeat(process.stdout.columns));
+
+    list.forEach((x: OssIndexServerResult, i: number) => {
+      if (x.vulnerabilities && x.vulnerabilities.length > 0) {
+        this.printVulnerability(i, total, x);
+      } else {
+        this.printLine(chalk.keyword('green')(`[${i + 1}/${total}] - ${x.toAuditLog()}`));
+      }
+    });
+
+    this.printLine('-'.repeat(process.stdout.columns));
+  }
+
+  private getColorFromMaxScore(maxScore: number, defaultColor = 'chartreuse'): string {
+    if (maxScore > 8) {
+      defaultColor = 'red';
+    } else if (maxScore > 6) {
+      defaultColor = 'orange';
+    } else if (maxScore > 4) {
+      defaultColor = 'yellow';
+    }
+    return defaultColor;
+  }
+
+  private printVulnerability(i: number, total: number, result: OssIndexServerResult): void {
+    if (!result.vulnerabilities) {
+      return;
+    }
+    const maxScore: number = Math.max(
+      ...result.vulnerabilities.map((x: Vulnerability) => {
+        return +x.cvssScore;
+      }),
+    );
+    const printVuln = (x: Array<Vulnerability>): void => {
+      x.forEach((y: Vulnerability) => {
+        const color: string = this.getColorFromMaxScore(+y.cvssScore);
+        console.group();
+        console.log(chalk.keyword(color)(`Vulnerability Title: `), `${y.title}`);
+        console.log(chalk.keyword(color)(`ID: `), `${y.id}`);
+        console.log(chalk.keyword(color)(`Description: `), `${y.description}`);
+        console.log(chalk.keyword(color)(`CVSS Score: `), `${y.cvssScore}`);
+        console.log(chalk.keyword(color)(`CVSS Vector: `), `${y.cvssVector}`);
+        console.log(chalk.keyword(color)(`CVE: `), `${y.cve}`);
+        console.log(chalk.keyword(color)(`Reference: `), `${y.reference}`);
+        console.log();
+        console.groupEnd();
+      });
+    };
+
+    console.log(
+      chalk.keyword(this.getColorFromMaxScore(maxScore)).bold(`[${i + 1}/${total}] - ${result.toAuditLog()}`),
+    );
+    console.log();
+    result.vulnerabilities &&
+      printVuln(
+        result.vulnerabilities.sort((x, y) => {
+          return +y.cvssScore - +x.cvssScore;
+        }),
+      );
+  }
+
+  private printLine(line: any): void {
+    if (!this.quiet) {
+      console.log(line);
+    }
+  }
+
+  private suggestIncludeDevDeps(total: number) {
+    this.printLine(`Total dependencies audited: ${total}`);
+    if (total == 0) {
+      this.printLine(
+        `We noticed you had 0 dependencies, we exclude devDependencies by default, try running with --dev if you want to include those as well`,
+      );
+    }
+  }
 }

--- a/src/Audit/Formatters/TextFormatter.ts
+++ b/src/Audit/Formatters/TextFormatter.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Formatter } from './Formatter';
+import { OssIndexServerResult } from '../../Types/OssIndexServerResult';
+
+export class TextFormatter implements Formatter {
+  public printAuditResults(list: Array<OssIndexServerResult>) {}
+}

--- a/src/Audit/Formatters/XmlFormatter.ts
+++ b/src/Audit/Formatters/XmlFormatter.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as builder from 'xmlbuilder';
+
+import { Formatter, getNumberOfVulnerablePackagesFromResults } from './Formatter';
+import { OssIndexServerResult, Vulnerability } from '../../Types/OssIndexServerResult';
+
+export class XmlFormatter implements Formatter {
+  public printAuditResults(list: Array<OssIndexServerResult>) {
+    const testsuite = builder.create('testsuite');
+    testsuite.att('tests', list.length);
+    testsuite.att('timestamp', new Date().toISOString());
+    testsuite.att('failures', getNumberOfVulnerablePackagesFromResults(list));
+
+    for (let i = 0; i < list.length; i++) {
+      const testcase = testsuite.ele('testcase', { classname: list[i].coordinates, name: list[i].coordinates });
+      const vulns = list[i].vulnerabilities;
+
+      if (vulns) {
+        if (vulns.length > 0) {
+          const failure = testcase.ele('failure');
+          let failureText = '';
+          for (let j = 0; j < vulns.length; j++) {
+            failureText += this.getVulnerabilityForXmlBlock(vulns[j]) + '\n';
+          }
+          failure.text(failureText);
+          failure.att('type', 'Vulnerability detected');
+        }
+      }
+    }
+
+    const xml = testsuite.end({ pretty: true });
+
+    console.log(xml);
+  }
+
+  private getVulnerabilityForXmlBlock(vuln: Vulnerability): string {
+    let vulnBlock = '';
+    vulnBlock += `Vulnerability Title: ${vuln.title}\n`;
+    vulnBlock += `ID: ${vuln.id}\n`;
+    vulnBlock += `Description: ${vuln.description}\n`;
+    vulnBlock += `CVSS Score: ${vuln.cvssScore}\n`;
+    vulnBlock += `CVSS Vector: ${vuln.cvssVector}\n`;
+    vulnBlock += `CVE: ${vuln.cve}\n`;
+    vulnBlock += `Reference: ${vuln.reference}\n`;
+
+    return vulnBlock;
+  }
+}


### PR DESCRIPTION
Basically, we output things a lot of different ways, why not abstract the formatters? 

This pull request makes the following changes:
* Adds a `Formatter` interface
* Creates a few `Formatter` implementations, JSON, XML, Text
* Moves JSON and Text to using the formatter

This doesn't IMMEDIATELY solve the linked issue, but will once finished, as it abstracts the "quiet" away from the "json", etc...

It relates to the following issue #s:
* Fixes #179 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
