### PR TITLE
-d flag *in*cludes dev dependencies, not *ex*cludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Options:
   --user, -u         Specify username for request    [string] [default: "admin"]
   --password, -p     Specify password for request [string] [default: "admin123"]
   --artie, -x        Artie                                             [boolean]
-  --dev, -d          Exclude Development Dependencies                  [boolean]
+  --dev, -d          Include Development Dependencies                  [boolean]
 ```
 
 #### AuditJS usage with IQ Server, and what to expect

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ let argv = yargs
       dev: {
         alias: 'd',
         type: 'boolean',
-        description: 'Exclude Development Dependencies',
+        description: 'Include Development Dependencies',
         demandOption: false,
       },
     });


### PR DESCRIPTION
fix a typo in flag description

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
