### PR TITLE
(bug) Fixed NPE in logger if meta is not passed in

### DIFF
--- a/src/Application/Logger/Logger.ts
+++ b/src/Application/Logger/Logger.ts
@@ -25,8 +25,8 @@ const logPath = join(homedir(), '.ossindex');
 
 const logPathFile = join(logPath, '.auditjs.combined.log');
 
-addLayout('json', function(config) {
-  return function(logEvent) {
+addLayout('json', function (config) {
+  return function (logEvent) {
     return JSON.stringify(logEvent) + config.separator;
   };
 });
@@ -66,7 +66,7 @@ export const logMessage = (message: string, level: string, ...meta: any) => {
   if (level == DEBUG) {
     logger.debug(message, ...meta);
   } else if (level == ERROR) {
-    if (meta[0].stack) {
+    if (meta && meta[0] && meta[0].stack) {
       logger.error(message, meta[0].stack);
     } else {
       logger.error(message, ...meta);


### PR DESCRIPTION
I found a bug where if you don't do a `npm install` and just run auditjs, you get a NPE error in the logger.

## Before
```
➜  auditjs git:(logger_npe) ✗ auditjs ossi                            
 ________   ___  ___   ________   ___   _________       ___   ________      
|\   __  \ |\  \|\  \ |\   ___ \ |\  \ |\___   ___\    |\  \ |\   ____\     
\ \  \|\  \\ \  \\\  \\ \  \_|\ \\ \  \\|___ \  \_|    \ \  \\ \  \___|_    
 \ \   __  \\ \  \\\  \\ \  \ \\ \\ \  \    \ \  \   __ \ \  \\ \_____  \   
  \ \  \ \  \\ \  \\\  \\ \  \_\\ \\ \  \    \ \  \ |\  \\_\  \\|____|\  \  
   \ \__\ \__\\ \_______\\ \_______\\ \__\    \ \__\\ \________\ ____\_\  \ 
    \|__|\|__| \|_______| \|_______| \|__|     \|__| \|________||\_________\
                                                                \|_________|
                                                                            
                                                                            
  _      _                       _   _              
 /_)    /_`_  _  _ _/_   _  _   (/  /_`_._  _   _/ _
/_)/_/ ._//_// //_|/ /_//_//_' (_X /  ///_'/ //_/_\ 
   _/                _//                            

  AuditJS version: 4.0.10

✔ Starting application
TypeError: Cannot read property 'stack' of undefined
    at Object.exports.logMessage.meta [as logMessage] (/usr/local/lib/node_modules/auditjs/bin/Application/Logger/Logger.js:64:21)
    at new Application (/usr/local/lib/node_modules/auditjs/bin/Application/Application.js:65:22)
    at Object.<anonymous> (/usr/local/lib/node_modules/auditjs/bin/index.js:187:23)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
```

## After
```
node ../auditjs/bin/index.js ossi
 ________   ___  ___   ________   ___   _________       ___   ________      
|\   __  \ |\  \|\  \ |\   ___ \ |\  \ |\___   ___\    |\  \ |\   ____\     
\ \  \|\  \\ \  \\\  \\ \  \_|\ \\ \  \\|___ \  \_|    \ \  \\ \  \___|_    
 \ \   __  \\ \  \\\  \\ \  \ \\ \\ \  \    \ \  \   __ \ \  \\ \_____  \   
  \ \  \ \  \\ \  \\\  \\ \  \_\\ \\ \  \    \ \  \ |\  \\_\  \\|____|\  \  
   \ \__\ \__\\ \_______\\ \_______\\ \__\    \ \__\\ \________\ ____\_\  \ 
    \|__|\|__| \|_______| \|_______| \|__|     \|__| \|________||\_________\
                                                                \|_________|
                                                                            
                                                                            
  _      _                       _   _              
 /_)    /_`_  _  _ _/_   _  _   (/  /_`_._  _   _/ _
/_)/_/ ._//_// //_|/ /_//_//_' (_X /  ///_'/ //_/_\ 
   _/                _//                            

  AuditJS version: 4.0.10

✔ Starting application
[2020-03-10T10:56:31.822] [ERROR] auditjs - Failed project directory validation.  Are you in a (built) node, yarn, or bower project directory?
Error: Could not instantiate muncher
    at new Application (/Users/tlevett/git/auditjs/bin/Application/Application.js:66:19)
    at Object.<anonymous> (/Users/tlevett/git/auditjs/bin/index.js:187:23)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)

```

This pull request makes the following changes:
* Add in truthy checks to avoid npe

It relates to the following issue #s:
* I figured i'd be faster to create the PR than issue. yolo

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
