### PR TITLE
Show what dep brought in a dep, also the path to it

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -184,7 +184,7 @@ export class Application {
       this.spinner.maybeStop();
 
       logMessage('Attempting to audit results', DEBUG);
-      const failed = auditOSSIndex.auditResults(ossIndexResults);
+      const failed = auditOSSIndex.auditResults(ossIndexResults, this.results);
 
       logMessage('Results audited', DEBUG, { failureCode: failed });
       failed ? shutDownLoggerAndExit(1) : shutDownLoggerAndExit(0);

--- a/src/Audit/AuditOSSIndex.spec.ts
+++ b/src/Audit/AuditOSSIndex.spec.ts
@@ -28,7 +28,7 @@ const oldWrite = process.stdout.write;
 
 const doAuditOSSIndex = (results: OssIndexServerResult[]): boolean => {
   process.stdout.write = write;
-  const auditResult = auditOSSIndex.auditResults(results);
+  const auditResult = auditOSSIndex.auditResults(results, []);
   process.stdout.write = oldWrite;
   return auditResult;
 };

--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -18,6 +18,7 @@ import { Formatter, getNumberOfVulnerablePackagesFromResults } from './Formatter
 import { JsonFormatter } from './Formatters/JsonFormatter';
 import { TextFormatter } from './Formatters/TextFormatter';
 import { XmlFormatter } from './Formatters/XmlFormatter';
+import { Coordinates } from '../Types/Coordinates';
 
 export class AuditOSSIndex {
   private formatter: Formatter;
@@ -32,11 +33,16 @@ export class AuditOSSIndex {
     }
   }
 
-  public auditResults(results: Array<OssIndexServerResult>): boolean {
+  public auditResults(results: Array<OssIndexServerResult>, supplemental: Array<Coordinates>): boolean {
     if (this.quiet) {
       results = results.filter((x) => {
         return x.vulnerabilities && x.vulnerabilities?.length > 0;
       });
+    }
+    for (let i = 0; i < supplemental.length; i++) {
+      let index = results.findIndex((res) => res.coordinates == supplemental[i].toPurl());
+      results[index].requiredBy = Array.from(supplemental[i].requestedBy).join(', ');
+      results[index].realPath = supplemental[i].pathOnDisk;
     }
 
     this.formatter.printAuditResults(results);

--- a/src/Audit/AuditOSSIndex.ts
+++ b/src/Audit/AuditOSSIndex.ts
@@ -40,7 +40,7 @@ export class AuditOSSIndex {
       });
     }
     for (let i = 0; i < supplemental.length; i++) {
-      let index = results.findIndex((res) => res.coordinates == supplemental[i].toPurl());
+      const index = results.findIndex((res) => res.coordinates == supplemental[i].toPurl());
       results[index].requiredBy = Array.from(supplemental[i].requestedBy).join(', ');
       results[index].realPath = supplemental[i].pathOnDisk;
     }

--- a/src/Audit/Formatters/TextFormatter.ts
+++ b/src/Audit/Formatters/TextFormatter.ts
@@ -40,6 +40,10 @@ export class TextFormatter implements Formatter {
         this.printVulnerability(i, total, x);
       } else {
         this.printLine(chalk.keyword('green')(`[${i + 1}/${total}] - ${x.toAuditLog()}`));
+        console.group();
+        this.printLine(chalk.keyword('green')(`Path: ${x.realPath}`));
+        this.printLine(chalk.keyword('green')(`Required By: ${x.requiredBy}`));
+        console.groupEnd();
       }
     });
 
@@ -85,6 +89,8 @@ export class TextFormatter implements Formatter {
     console.log(
       chalk.keyword(this.getColorFromMaxScore(maxScore)).bold(`[${i + 1}/${total}] - ${result.toAuditLog()}`),
     );
+    console.log(chalk.keyword(this.getColorFromMaxScore(maxScore)).bold(`Path: ${result.realPath}`));
+    console.log(chalk.keyword(this.getColorFromMaxScore(maxScore)).bold(`Required By: ${result.requiredBy}`));
     console.log();
     result.vulnerabilities &&
       printVuln(

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -112,7 +112,9 @@ export class NpmList implements Muncher {
       pkg._requiredBy.forEach((item: string) => {
         set.add(item);
       });
-      list.push(new Coordinates(name[1], pkg.version, name[0], set));
+      list.push(
+        new Coordinates(name[1], pkg.version, name[0], set, this.stripPwdAndNodeModulesFromRealPath(pkg.realPath)),
+      );
       return true;
     } else if (pkg.name) {
       if (
@@ -131,7 +133,7 @@ export class NpmList implements Muncher {
       pkg._requiredBy.forEach((item: string) => {
         set.add(item);
       });
-      list.push(new Coordinates(pkg.name, pkg.version, '', set));
+      list.push(new Coordinates(pkg.name, pkg.version, '', set, this.stripPwdAndNodeModulesFromRealPath(pkg.realPath)));
       return true;
     }
     return false;
@@ -153,5 +155,11 @@ export class NpmList implements Muncher {
       return `${group}/${name}/${version}`;
     }
     return `${name}/${version}`;
+  }
+
+  private stripPwdAndNodeModulesFromRealPath(realPath: string): string {
+    const cwd = process.cwd();
+
+    return realPath.substr(cwd.length);
   }
 }

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -108,7 +108,7 @@ export class NpmList implements Muncher {
 
         return false;
       }
-      let set = new Set<string>();
+      const set = new Set<string>();
       pkg._requiredBy.forEach((item: string) => {
         set.add(item);
       });
@@ -129,7 +129,7 @@ export class NpmList implements Muncher {
 
         return false;
       }
-      let set = new Set<string>();
+      const set = new Set<string>();
       pkg._requiredBy.forEach((item: string) => {
         set.add(item);
       });

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -101,9 +101,18 @@ export class NpmList implements Muncher {
           return x.name == name[1] && x.version == pkg.version && x.group == name[0];
         })
       ) {
+        const foundIndex = list.findIndex((x) => x.name == name[1] && x.version == pkg.version && x.group == name[0]);
+        pkg._requiredBy.forEach((item: string) => {
+          list[foundIndex].requestedBy.add(item);
+        });
+
         return false;
       }
-      list.push(new Coordinates(name[1], pkg.version, name[0]));
+      let set = new Set<string>();
+      pkg._requiredBy.forEach((item: string) => {
+        set.add(item);
+      });
+      list.push(new Coordinates(name[1], pkg.version, name[0], set));
       return true;
     } else if (pkg.name) {
       if (
@@ -111,9 +120,18 @@ export class NpmList implements Muncher {
           return x.name == pkg.name && x.version == pkg.version && x.group == '';
         })
       ) {
+        const foundIndex = list.findIndex((x) => x.name == pkg.name && x.version == pkg.version && x.group == '');
+        pkg._requiredBy.forEach((item: string) => {
+          list[foundIndex].requestedBy.add(item);
+        });
+
         return false;
       }
-      list.push(new Coordinates(pkg.name, pkg.version, ''));
+      let set = new Set<string>();
+      pkg._requiredBy.forEach((item: string) => {
+        set.add(item);
+      });
+      list.push(new Coordinates(pkg.name, pkg.version, '', set));
       return true;
     }
     return false;

--- a/src/Types/Coordinates.ts
+++ b/src/Types/Coordinates.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 export class Coordinates {
-  constructor(readonly name: string, readonly version: string, readonly group?: string) {}
+  constructor(
+    readonly name: string,
+    readonly version: string,
+    readonly group?: string,
+    public requestedBy: Set<string> = new Set(),
+  ) {}
 
   public toPurl(ecosystem = 'npm'): string {
     if (this.group) {

--- a/src/Types/Coordinates.ts
+++ b/src/Types/Coordinates.ts
@@ -19,6 +19,7 @@ export class Coordinates {
     readonly version: string,
     readonly group?: string,
     public requestedBy: Set<string> = new Set(),
+    public pathOnDisk: string = '',
   ) {}
 
   public toPurl(ecosystem = 'npm'): string {

--- a/src/Types/OssIndexServerResult.ts
+++ b/src/Types/OssIndexServerResult.ts
@@ -18,6 +18,8 @@ export class OssIndexServerResult {
   readonly description?: string;
   readonly reference: string;
   readonly vulnerabilities?: Array<Vulnerability>;
+  public requiredBy: string = '';
+  public realPath: string = '';
 
   constructor(result: any) {
     this.coordinates = result.coordinates;

--- a/src/Types/OssIndexServerResult.ts
+++ b/src/Types/OssIndexServerResult.ts
@@ -18,8 +18,8 @@ export class OssIndexServerResult {
   readonly description?: string;
   readonly reference: string;
   readonly vulnerabilities?: Array<Vulnerability>;
-  public requiredBy: string = '';
-  public realPath: string = '';
+  public requiredBy = '';
+  public realPath = '';
 
   constructor(result: any) {
     this.coordinates = result.coordinates;


### PR DESCRIPTION
To help devs figure out how to remediate, it was suggested to add the:

- list of deps that require the dep
- the path to the dep

This gives a developer a lot of information to go on to figure out why something was brought in.

This pull request makes the following changes:
* Adds fields for what required a dependency, populates them as we parse the list from read-installed
* Adds a field for the realPath to the dependency, populates it
* Passes both the read-installed coordinates and ossindexserverresults to Audit, and merges them
* Outputs the dependency information:

<img width="852" alt="Screen Shot 2020-03-19 at 12 01 47 PM" src="https://user-images.githubusercontent.com/5544326/77110944-42effd80-69db-11ea-8539-d685a6f97b86.png">

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
