### PR TITLE
Pipe cyclonedx sbom to std_out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm-wee
-          command: npm install
+          command: npm install package-lock.json
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm-wee
-          command: npm install package-lock.json
+          command: npm ci install
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": true
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,11 +2819,6 @@
         "release-zalgo": "^1.0.0"
       }
     },
-    "package-lock.json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
-      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2179,17 +2179,16 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
       }
     },
     "mocha": {
@@ -2819,6 +2818,11 @@
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
       }
+    },
+    "package-lock.json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
+      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "node-fetch": "^2.6.0",
     "node-persist": "^3.0.5",
     "ora": "^4.0.3",
+    "package-lock.json": "^1.0.0",
     "read-installed": "~4.0.3",
     "spdx-license-ids": "^3.0.5",
     "ssri": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint src/**/*.ts",
     "start": "node ./bin/index.js",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run test"
+    "prepublishOnly": "npm run test",
+    "iq-scan": "npx auditjs@latest iq -a auditjs"
   },
   "keywords": [
     "Audit",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "node-fetch": "^2.6.0",
     "node-persist": "^3.0.5",
     "ora": "^4.0.3",
-    "package-lock.json": "^1.0.0",
     "read-installed": "~4.0.3",
     "spdx-license-ids": "^3.0.5",
     "ssri": "^6.0.0",

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -13,24 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { textSync } from 'figlet';
+import {textSync} from 'figlet';
 
-import { IqRequestService } from '../Services/IqRequestService';
-import { NpmList } from '../Munchers/NpmList';
-import { Coordinates } from '../Types/Coordinates';
-import { Muncher } from '../Munchers/Muncher';
-import { OssIndexRequestService } from '../Services/OssIndexRequestService';
-import { AuditIQServer } from '../Audit/AuditIQServer';
-import { AuditOSSIndex } from '../Audit/AuditOSSIndex';
-import { OssIndexServerResult } from '../Types/OssIndexServerResult';
-import { ReportStatus } from '../Types/ReportStatus';
-import { Bower } from '../Munchers/Bower';
-import { DEBUG, ERROR, logMessage, createAppLogger, shutDownLoggerAndExit } from './Logger/Logger';
-import { Spinner } from './Spinner/Spinner';
-import { filterVulnerabilities } from '../Whitelist/VulnerabilityExcluder';
-import { IqServerConfig } from '../Config/IqServerConfig';
-import { OssIndexServerConfig } from '../Config/OssIndexServerConfig';
-import { visuallySeperateText } from '../Visual/VisualHelper';
+import {IqRequestService} from '../Services/IqRequestService';
+import {NpmList} from '../Munchers/NpmList';
+import {Coordinates} from '../Types/Coordinates';
+import {Muncher} from '../Munchers/Muncher';
+import {OssIndexRequestService} from '../Services/OssIndexRequestService';
+import {AuditIQServer} from '../Audit/AuditIQServer';
+import {AuditOSSIndex} from '../Audit/AuditOSSIndex';
+import {OssIndexServerResult} from '../Types/OssIndexServerResult';
+import {ReportStatus} from '../Types/ReportStatus';
+import {Bower} from '../Munchers/Bower';
+import {DEBUG, ERROR, logMessage, createAppLogger, shutDownLoggerAndExit} from './Logger/Logger';
+import {Spinner} from './Spinner/Spinner';
+import {filterVulnerabilities} from '../Whitelist/VulnerabilityExcluder';
+import {IqServerConfig} from '../Config/IqServerConfig';
+import {OssIndexServerConfig} from '../Config/OssIndexServerConfig';
+import {visuallySeperateText} from '../Visual/VisualHelper';
 const pj = require('../../package.json');
 
 export class Application {
@@ -92,6 +92,9 @@ export class Application {
       logMessage('Auditing your application with Sonatype OSS Index', DEBUG);
       this.spinner.maybeCreateMessageForSpinner('Auditing your application with Sonatype OSS Index');
       await this.auditWithOSSIndex(args);
+    } else if (args._[0] == 'sbom') {
+      await this.populateCoordinatesForIQ();
+      console.log(this.sbom)
     } else {
       shutDownLoggerAndExit(0);
     }
@@ -110,8 +113,8 @@ export class Application {
   }
 
   private doPrintHeader(title = 'AuditJS', font: figlet.Fonts = '3D-ASCII'): void {
-    console.log(textSync(title, { font: font, horizontalLayout: 'fitted' }));
-    console.log(textSync('By Sonatype & Friends', { font: 'Pepper' }));
+    console.log(textSync(title, {font: font, horizontalLayout: 'fitted'}));
+    console.log(textSync('By Sonatype & Friends', {font: 'Pepper'}));
     visuallySeperateText(false, [`${title} version: ${pj.version}`]);
   }
 
@@ -152,7 +155,7 @@ export class Application {
     this.spinner.maybeCreateMessageForSpinner('Submitting coordinates to Sonatype OSS Index');
 
     const format = this.muncher instanceof Bower ? 'bower' : 'npm';
-    logMessage('Format to query OSS Index picked', DEBUG, { format: format });
+    logMessage('Format to query OSS Index picked', DEBUG, {format: format});
     try {
       logMessage('Attempting to query OSS Index or use Cache', DEBUG);
       const res = await requestService.callOSSIndexOrGetFromCache(this.results, format);
@@ -170,13 +173,13 @@ export class Application {
       this.spinner.maybeSucceed();
 
       this.spinner.maybeCreateMessageForSpinner('Removing whitelisted vulnerabilities');
-      logMessage('Response being ran against whitelist', DEBUG, { ossIndexServerResults: ossIndexResults });
+      logMessage('Response being ran against whitelist', DEBUG, {ossIndexServerResults: ossIndexResults});
       ossIndexResults = await filterVulnerabilities(ossIndexResults);
-      logMessage('Response has been whitelisted', DEBUG, { ossIndexServerResults: ossIndexResults });
+      logMessage('Response has been whitelisted', DEBUG, {ossIndexServerResults: ossIndexResults});
       this.spinner.maybeSucceed();
 
       this.spinner.maybeCreateMessageForSpinner('Auditing your results from Sonatype OSS Index');
-      logMessage('Instantiating OSS Index Request Service, with quiet option', DEBUG, { quiet: args.quiet });
+      logMessage('Instantiating OSS Index Request Service, with quiet option', DEBUG, {quiet: args.quiet});
       const auditOSSIndex = new AuditOSSIndex(
         args.quiet ? true : false,
         args.json ? true : false,
@@ -187,11 +190,11 @@ export class Application {
       logMessage('Attempting to audit results', DEBUG);
       const failed = auditOSSIndex.auditResults(ossIndexResults);
 
-      logMessage('Results audited', DEBUG, { failureCode: failed });
+      logMessage('Results audited', DEBUG, {failureCode: failed});
       failed ? shutDownLoggerAndExit(1) : shutDownLoggerAndExit(0);
     } catch (e) {
       this.spinner.maybeStop();
-      logMessage('There was an error auditing with Sonatype OSS Index', ERROR, { title: e.message, stack: e.stack });
+      logMessage('There was an error auditing with Sonatype OSS Index', ERROR, {title: e.message, stack: e.stack});
       shutDownLoggerAndExit(1);
     }
   }
@@ -216,7 +219,7 @@ export class Application {
         `${resultUrl}`,
         (e) => {
           this.spinner.maybeFail();
-          logMessage('There was an issue auditing your application!', ERROR, { title: e.message, stack: e.stack });
+          logMessage('There was an issue auditing your application!', ERROR, {title: e.message, stack: e.stack});
           shutDownLoggerAndExit(1);
         },
         (x) => {
@@ -230,14 +233,14 @@ export class Application {
           this.spinner.maybeStop();
           logMessage('Auditing results', DEBUG, results);
           const failure = auditResults.auditThirdPartyResults(results);
-          logMessage('Audit finished', DEBUG, { failure: failure });
+          logMessage('Audit finished', DEBUG, {failure: failure});
 
           failure ? shutDownLoggerAndExit(1) : shutDownLoggerAndExit(0);
         },
       );
     } catch (e) {
       this.spinner.maybeFail();
-      logMessage('There was an issue auditing your application!', ERROR, { title: e.message, stack: e.stack });
+      logMessage('There was an issue auditing your application!', ERROR, {title: e.message, stack: e.stack});
       shutDownLoggerAndExit(1);
     }
   }

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -13,24 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {textSync} from 'figlet';
+import { textSync } from 'figlet';
 
-import {IqRequestService} from '../Services/IqRequestService';
-import {NpmList} from '../Munchers/NpmList';
-import {Coordinates} from '../Types/Coordinates';
-import {Muncher} from '../Munchers/Muncher';
-import {OssIndexRequestService} from '../Services/OssIndexRequestService';
-import {AuditIQServer} from '../Audit/AuditIQServer';
-import {AuditOSSIndex} from '../Audit/AuditOSSIndex';
-import {OssIndexServerResult} from '../Types/OssIndexServerResult';
-import {ReportStatus} from '../Types/ReportStatus';
-import {Bower} from '../Munchers/Bower';
-import {DEBUG, ERROR, logMessage, createAppLogger, shutDownLoggerAndExit} from './Logger/Logger';
-import {Spinner} from './Spinner/Spinner';
-import {filterVulnerabilities} from '../Whitelist/VulnerabilityExcluder';
-import {IqServerConfig} from '../Config/IqServerConfig';
-import {OssIndexServerConfig} from '../Config/OssIndexServerConfig';
-import {visuallySeperateText} from '../Visual/VisualHelper';
+import { IqRequestService } from '../Services/IqRequestService';
+import { NpmList } from '../Munchers/NpmList';
+import { Coordinates } from '../Types/Coordinates';
+import { Muncher } from '../Munchers/Muncher';
+import { OssIndexRequestService } from '../Services/OssIndexRequestService';
+import { AuditIQServer } from '../Audit/AuditIQServer';
+import { AuditOSSIndex } from '../Audit/AuditOSSIndex';
+import { OssIndexServerResult } from '../Types/OssIndexServerResult';
+import { ReportStatus } from '../Types/ReportStatus';
+import { Bower } from '../Munchers/Bower';
+import { DEBUG, ERROR, logMessage, createAppLogger, shutDownLoggerAndExit } from './Logger/Logger';
+import { Spinner } from './Spinner/Spinner';
+import { filterVulnerabilities } from '../Whitelist/VulnerabilityExcluder';
+import { IqServerConfig } from '../Config/IqServerConfig';
+import { OssIndexServerConfig } from '../Config/OssIndexServerConfig';
+import { visuallySeperateText } from '../Visual/VisualHelper';
 const pj = require('../../package.json');
 
 export class Application {
@@ -94,7 +94,7 @@ export class Application {
       await this.auditWithOSSIndex(args);
     } else if (args._[0] == 'sbom') {
       await this.populateCoordinatesForIQ();
-      console.log(this.sbom)
+      console.log(this.sbom);
     } else {
       shutDownLoggerAndExit(0);
     }
@@ -113,8 +113,8 @@ export class Application {
   }
 
   private doPrintHeader(title = 'AuditJS', font: figlet.Fonts = '3D-ASCII'): void {
-    console.log(textSync(title, {font: font, horizontalLayout: 'fitted'}));
-    console.log(textSync('By Sonatype & Friends', {font: 'Pepper'}));
+    console.log(textSync(title, { font: font, horizontalLayout: 'fitted' }));
+    console.log(textSync('By Sonatype & Friends', { font: 'Pepper' }));
     visuallySeperateText(false, [`${title} version: ${pj.version}`]);
   }
 
@@ -155,7 +155,7 @@ export class Application {
     this.spinner.maybeCreateMessageForSpinner('Submitting coordinates to Sonatype OSS Index');
 
     const format = this.muncher instanceof Bower ? 'bower' : 'npm';
-    logMessage('Format to query OSS Index picked', DEBUG, {format: format});
+    logMessage('Format to query OSS Index picked', DEBUG, { format: format });
     try {
       logMessage('Attempting to query OSS Index or use Cache', DEBUG);
       const res = await requestService.callOSSIndexOrGetFromCache(this.results, format);
@@ -173,13 +173,13 @@ export class Application {
       this.spinner.maybeSucceed();
 
       this.spinner.maybeCreateMessageForSpinner('Removing whitelisted vulnerabilities');
-      logMessage('Response being ran against whitelist', DEBUG, {ossIndexServerResults: ossIndexResults});
+      logMessage('Response being ran against whitelist', DEBUG, { ossIndexServerResults: ossIndexResults });
       ossIndexResults = await filterVulnerabilities(ossIndexResults);
-      logMessage('Response has been whitelisted', DEBUG, {ossIndexServerResults: ossIndexResults});
+      logMessage('Response has been whitelisted', DEBUG, { ossIndexServerResults: ossIndexResults });
       this.spinner.maybeSucceed();
 
       this.spinner.maybeCreateMessageForSpinner('Auditing your results from Sonatype OSS Index');
-      logMessage('Instantiating OSS Index Request Service, with quiet option', DEBUG, {quiet: args.quiet});
+      logMessage('Instantiating OSS Index Request Service, with quiet option', DEBUG, { quiet: args.quiet });
       const auditOSSIndex = new AuditOSSIndex(
         args.quiet ? true : false,
         args.json ? true : false,
@@ -190,11 +190,11 @@ export class Application {
       logMessage('Attempting to audit results', DEBUG);
       const failed = auditOSSIndex.auditResults(ossIndexResults);
 
-      logMessage('Results audited', DEBUG, {failureCode: failed});
+      logMessage('Results audited', DEBUG, { failureCode: failed });
       failed ? shutDownLoggerAndExit(1) : shutDownLoggerAndExit(0);
     } catch (e) {
       this.spinner.maybeStop();
-      logMessage('There was an error auditing with Sonatype OSS Index', ERROR, {title: e.message, stack: e.stack});
+      logMessage('There was an error auditing with Sonatype OSS Index', ERROR, { title: e.message, stack: e.stack });
       shutDownLoggerAndExit(1);
     }
   }
@@ -219,7 +219,7 @@ export class Application {
         `${resultUrl}`,
         (e) => {
           this.spinner.maybeFail();
-          logMessage('There was an issue auditing your application!', ERROR, {title: e.message, stack: e.stack});
+          logMessage('There was an issue auditing your application!', ERROR, { title: e.message, stack: e.stack });
           shutDownLoggerAndExit(1);
         },
         (x) => {
@@ -233,14 +233,14 @@ export class Application {
           this.spinner.maybeStop();
           logMessage('Auditing results', DEBUG, results);
           const failure = auditResults.auditThirdPartyResults(results);
-          logMessage('Audit finished', DEBUG, {failure: failure});
+          logMessage('Audit finished', DEBUG, { failure: failure });
 
           failure ? shutDownLoggerAndExit(1) : shutDownLoggerAndExit(0);
         },
       );
     } catch (e) {
       this.spinner.maybeFail();
-      logMessage('There was an issue auditing your application!', ERROR, {title: e.message, stack: e.stack});
+      logMessage('There was an issue auditing your application!', ERROR, { title: e.message, stack: e.stack });
       shutDownLoggerAndExit(1);
     }
   }

--- a/src/CycloneDX/CycloneDXSbomCreator.spec.ts
+++ b/src/CycloneDX/CycloneDXSbomCreator.spec.ts
@@ -55,7 +55,9 @@ const object = {
   },
 };
 
-const expectedResponse = `<?xml version="1.0" encoding="utf-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1"><components><component type="library" bom-ref="pkg:npm/testdependency@1.0.1"><name>testdependency</name><version>1.0.1</version><description/><purl>pkg:npm/testdependency@1.0.1</purl><externalReferences><reference type="issue-tracker"><url>git+ssh://git@github.com/slackhq/csp-html-webpack-plugin.git</url></reference></externalReferences></component><component type="library" bom-ref="pkg:npm/testdependency2@1.0.2"><name>testdependency2</name><version>1.0.2</version><description/><purl>pkg:npm/testdependency2@1.0.2</purl></component><component type="library" bom-ref="pkg:npm/testdependency@1.0.0"><name>testdependency</name><version>1.0.0</version><description/><purl>pkg:npm/testdependency@1.0.0</purl></component><component type="library" bom-ref="pkg:npm/%40scope/testdependency3@1.0.2"><group>@scope</group><name>testdependency3</name><version>1.0.2</version><description/><purl>pkg:npm/%40scope/testdependency3@1.0.2</purl></component></components></bom>`;
+const expectedResponse = `<?xml version="1.0" encoding="utf-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1"><components><component type="library" bom-ref="pkg:npm/testdependency@1.0.1"><name>testdependency</name><version>1.0.1</version><purl>pkg:npm/testdependency@1.0.1</purl><description/><externalReferences><reference type="issue-tracker"><url>git+ssh://git@github.com/slackhq/csp-html-webpack-plugin.git</url></reference></externalReferences></component><component type="library" bom-ref="pkg:npm/testdependency2@1.0.2"><name>testdependency2</name><version>1.0.2</version><purl>pkg:npm/testdependency2@1.0.2</purl><description/></component><component type="library" bom-ref="pkg:npm/testdependency@1.0.0"><name>testdependency</name><version>1.0.0</version><purl>pkg:npm/testdependency@1.0.0</purl><description/></component><component type="library" bom-ref="pkg:npm/%40scope/testdependency3@1.0.2"><group>@scope</group><name>testdependency3</name><version>1.0.2</version><purl>pkg:npm/%40scope/testdependency3@1.0.2</purl><description/></component></components></bom>`;
+
+const expectedSpartanResponse = `<?xml version="1.0" encoding="utf-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1"><components><component type="library" bom-ref="pkg:npm/testdependency@1.0.1"><name>testdependency</name><version>1.0.1</version><purl>pkg:npm/testdependency@1.0.1</purl></component><component type="library" bom-ref="pkg:npm/testdependency2@1.0.2"><name>testdependency2</name><version>1.0.2</version><purl>pkg:npm/testdependency2@1.0.2</purl></component><component type="library" bom-ref="pkg:npm/testdependency@1.0.0"><name>testdependency</name><version>1.0.0</version><purl>pkg:npm/testdependency@1.0.0</purl></component><component type="library" bom-ref="pkg:npm/%40scope/testdependency3@1.0.2"><group>@scope</group><name>testdependency3</name><version>1.0.2</version><purl>pkg:npm/%40scope/testdependency3@1.0.2</purl></component></components></bom>`;
 
 describe('CycloneDXSbomCreator', async () => {
   it('should create an sbom string given a minimal valid object', async () => {
@@ -64,5 +66,13 @@ describe('CycloneDXSbomCreator', async () => {
     const string = await sbomCreator.createBom(object);
 
     expect(string).to.eq(expectedResponse);
+  });
+
+  it('should create a spartan sbom string given a minimal valid object', async () => {
+    const sbomCreator = new CycloneDXSbomCreator(process.cwd(), { spartan: true });
+
+    const string = await sbomCreator.createBom(object);
+
+    expect(string).to.eq(expectedSpartanResponse);
   });
 });

--- a/src/CycloneDX/CycloneDXSbomCreator.ts
+++ b/src/CycloneDX/CycloneDXSbomCreator.ts
@@ -228,7 +228,11 @@ export class CycloneDXSbomCreator {
     return externalReferences;
   }
 
-  private pushURLToExternalReferences(typeOfURL: string, url: string, externalReferences: Array<ExternalReference>) {
+  private pushURLToExternalReferences(
+    typeOfURL: string,
+    url: string,
+    externalReferences: Array<ExternalReference>,
+  ): void {
     try {
       const uri = new URL(url);
       externalReferences.push({ reference: { '@type': typeOfURL, url: uri.toString() } });

--- a/src/CycloneDX/CycloneDXSbomCreator.ts
+++ b/src/CycloneDX/CycloneDXSbomCreator.ts
@@ -105,6 +105,7 @@ export class CycloneDXSbomCreator {
   }
 
   private addComponent(pkg: any, list: any, isRootPkg = false): void {
+    const spartan = this.options?.spartan ? this.options.spartan : false;
     //read-installed with default options marks devDependencies as extraneous
     //if a package is marked as extraneous, do not include it as a component
     if (pkg.extraneous) {
@@ -116,36 +117,39 @@ export class CycloneDXSbomCreator {
       const name: string = pkgIdentifier.fullName as string;
       const version: string = pkg.version as string;
       const purl: string = toPurl(name, version, group);
-      const description: GenericDescription = { '#cdata': pkg.description };
-
       const component: Component = {
         '@type': this.determinePackageType(pkg),
         '@bom-ref': purl,
         group: group,
         name: name,
         version: version,
-        description: description,
-        hashes: [],
-        licenses: [],
         purl: purl,
-        externalReferences: this.addExternalReferences(pkg),
       };
 
       if (component.group === '') {
         delete component.group;
       }
 
-      if (this.options && this.options.includeLicenseData) {
-        component.licenses = this.getLicenses(pkg);
-      } else {
-        delete component.licenses;
-      }
+      if (!spartan) {
+        const description: GenericDescription = { '#cdata': pkg.description };
 
-      if (component.externalReferences === undefined || component.externalReferences.length === 0) {
-        delete component.externalReferences;
-      }
+        component.description = description;
+        component.hashes = [];
+        component.licenses = [];
+        component.externalReferences = this.addExternalReferences(pkg);
 
-      this.processHashes(pkg, component);
+        if (this.options && this.options.includeLicenseData) {
+          component.licenses = this.getLicenses(pkg);
+        } else {
+          delete component.licenses;
+        }
+
+        if (component.externalReferences === undefined || component.externalReferences.length === 0) {
+          delete component.externalReferences;
+        }
+
+        this.processHashes(pkg, component);
+      }
 
       if (list[component.purl]) return; //remove cycles
       list[component.purl] = component;

--- a/src/CycloneDX/Options.ts
+++ b/src/CycloneDX/Options.ts
@@ -18,4 +18,5 @@ export interface Options {
   includeBomSerialNumber?: boolean;
   includeLicenseData?: boolean;
   includeLicenseText?: boolean;
+  spartan?: boolean;
 }

--- a/src/CycloneDX/Types/Component.ts
+++ b/src/CycloneDX/Types/Component.ts
@@ -13,23 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ExternalReference } from "./ExternalReference";
-import { Hash } from "./Hash";
+import { ExternalReference } from './ExternalReference';
+import { Hash } from './Hash';
 
 export interface Component {
-  '@type': string,
-  '@bom-ref': string,
-  group: string,
-  name: string,
-  version: string,
-  description: Object,
-  hashes?: Array<Hash>,
-  licenses?: Array<any>,
-  purl: string,
-  externalReferences?: Array<ExternalReference>
+  '@type': string;
+  '@bom-ref': string;
+  group: string;
+  name: string;
+  version: string;
+  description?: Object;
+  hashes?: Array<Hash>;
+  licenses?: Array<any>;
+  purl: string;
+  externalReferences?: Array<ExternalReference>;
 }
 
 export interface GenericDescription {
-  '#cdata': string,
-  '@content-type'?: string
+  '#cdata': string;
+  '@content-type'?: string;
 }

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Muncher} from './Muncher';
+import { Muncher } from './Muncher';
 import path from 'path';
 import fs from 'fs';
-import {Coordinates} from '../Types/Coordinates';
-import {CycloneDXSbomCreator} from '../CycloneDX/CycloneDXSbomCreator';
+import { Coordinates } from '../Types/Coordinates';
+import { CycloneDXSbomCreator } from '../CycloneDX/CycloneDXSbomCreator';
 
 export class NpmList implements Muncher {
   private depsArray: Array<Coordinates> = [];

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Muncher } from './Muncher';
+import {Muncher} from './Muncher';
 import path from 'path';
 import fs from 'fs';
-import { Coordinates } from '../Types/Coordinates';
-import { CycloneDXSbomCreator } from '../CycloneDX/CycloneDXSbomCreator';
+import {Coordinates} from '../Types/Coordinates';
+import {CycloneDXSbomCreator} from '../CycloneDX/CycloneDXSbomCreator';
 
 export class NpmList implements Muncher {
   private depsArray: Array<Coordinates> = [];
@@ -33,8 +33,6 @@ export class NpmList implements Muncher {
     return fs.existsSync(nodeModulesPath);
   }
 
-  // TODO: There is a 1 component discrepency in what gets identified by our installed deps implementation
-  // and what gets identified by the iq server being passed the sbom, gotta figure out what that is and why...
   public async getSbomFromCommand(): Promise<string> {
     const sbomCreator = new CycloneDXSbomCreator(process.cwd(), {
       devDependencies: this.devDependencies,
@@ -53,6 +51,8 @@ export class NpmList implements Muncher {
   public async getInstalledDeps(): Promise<Array<Coordinates>> {
     const sbomCreator = new CycloneDXSbomCreator(process.cwd(), {
       devDependencies: this.devDependencies,
+      includeLicenseData: false,
+      includeBomSerialNumber: true,
     });
 
     const data = await sbomCreator.getPackageInfoFromReadInstalled();

--- a/src/Munchers/NpmList.ts
+++ b/src/Munchers/NpmList.ts
@@ -38,6 +38,7 @@ export class NpmList implements Muncher {
       devDependencies: this.devDependencies,
       includeLicenseData: false,
       includeBomSerialNumber: true,
+      spartan: true,
     });
 
     const pkgInfo = await sbomCreator.getPackageInfoFromReadInstalled();

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 import yargs from 'yargs';
-import { Argv } from 'yargs';
-import { Application } from './Application/Application';
-import { AppConfig } from './Config/AppConfig';
-import { OssIndexServerConfig } from './Config/OssIndexServerConfig';
+import {Argv} from 'yargs';
+import {Application} from './Application/Application';
+import {AppConfig} from './Config/AppConfig';
+import {OssIndexServerConfig} from './Config/OssIndexServerConfig';
 
 // TODO: Flesh out the remaining set of args that NEED to be moved over, look at them with a fine toothed comb and lots of skepticism
 const normalizeHostAddress = (address: string) => {
@@ -140,7 +140,8 @@ let argv = yargs
         type: 'boolean',
         demandOption: false,
       },
-    });
+    })
+      .command('sbom', 'Output the purl only CycloneDx sbom to std_out');
   }).argv;
 
 if (argv) {
@@ -178,8 +179,9 @@ if (argv) {
         'Attempted to clear cache but no config file present, run `auditjs config` to set a cache location.',
       );
     }
-  } else if (argv._[0] == 'iq' || argv._[0] == 'ossi') {
-    let silence = argv.json || argv.quiet || argv.xml ? true : false;
+  } else if (argv._[0] == 'iq' || argv._[0] == 'ossi' || argv._[0] == 'sbom') {
+    // silence all output if quiet or if sending file to std_out
+    let silence = argv.json || argv.quiet || argv.xml || argv._[0] == 'sbom' ? true : false;
     let artie = argv.artie ? true : false;
     let allen = argv.allen ? true : false;
     let bower = argv.bower ? true : false;


### PR DESCRIPTION
Adding the 'sbom' subcommand to pipe the CycloneDx bom that gets submitted to IQ to std_out so that we can generate a portable bom file that can be ingested by scanners and IQ servers disconnected from the build environment.  

This command will be standard for all the Sonatype DevEx scanners that generate a CycloneDx bom

Tested successfully with no internet connection on a built project

Are there any arguments to the sbom command that we want to make standard?  Should we allow the DevEx scanners to append to existing sboms?  That would be a little harder but it covers the use case of an app with multiple ecosystems in it.  Should we allow AuditJS to submit a bom to IQ directly without resolving the dependencies?  

I think first step for MVP is to just output to the console for each tool and they can do whatever with that, but I would like to define a standard way of handling these exported reports across our tooling

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
