### PR TITLE
Spartan

### DIFF
--- a/src/CycloneDX/CycloneDXSbomCreator.spec.ts
+++ b/src/CycloneDX/CycloneDXSbomCreator.spec.ts
@@ -55,7 +55,9 @@ const object = {
   },
 };
 
-const expectedResponse = `<?xml version="1.0" encoding="utf-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1"><components><component type="library" bom-ref="pkg:npm/testdependency@1.0.1"><name>testdependency</name><version>1.0.1</version><description/><purl>pkg:npm/testdependency@1.0.1</purl><externalReferences><reference type="issue-tracker"><url>git+ssh://git@github.com/slackhq/csp-html-webpack-plugin.git</url></reference></externalReferences></component><component type="library" bom-ref="pkg:npm/testdependency2@1.0.2"><name>testdependency2</name><version>1.0.2</version><description/><purl>pkg:npm/testdependency2@1.0.2</purl></component><component type="library" bom-ref="pkg:npm/testdependency@1.0.0"><name>testdependency</name><version>1.0.0</version><description/><purl>pkg:npm/testdependency@1.0.0</purl></component><component type="library" bom-ref="pkg:npm/%40scope/testdependency3@1.0.2"><group>@scope</group><name>testdependency3</name><version>1.0.2</version><description/><purl>pkg:npm/%40scope/testdependency3@1.0.2</purl></component></components></bom>`;
+const expectedResponse = `<?xml version="1.0" encoding="utf-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1"><components><component type="library" bom-ref="pkg:npm/testdependency@1.0.1"><name>testdependency</name><version>1.0.1</version><purl>pkg:npm/testdependency@1.0.1</purl><description/><externalReferences><reference type="issue-tracker"><url>git+ssh://git@github.com/slackhq/csp-html-webpack-plugin.git</url></reference></externalReferences></component><component type="library" bom-ref="pkg:npm/testdependency2@1.0.2"><name>testdependency2</name><version>1.0.2</version><purl>pkg:npm/testdependency2@1.0.2</purl><description/></component><component type="library" bom-ref="pkg:npm/testdependency@1.0.0"><name>testdependency</name><version>1.0.0</version><purl>pkg:npm/testdependency@1.0.0</purl><description/></component><component type="library" bom-ref="pkg:npm/%40scope/testdependency3@1.0.2"><group>@scope</group><name>testdependency3</name><version>1.0.2</version><purl>pkg:npm/%40scope/testdependency3@1.0.2</purl><description/></component></components></bom>`;
+
+const expectedSpartanResponse = `<?xml version="1.0" encoding="utf-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.1" version="1"><components><component type="library" bom-ref="pkg:npm/testdependency@1.0.1"><name>testdependency</name><version>1.0.1</version><purl>pkg:npm/testdependency@1.0.1</purl></component><component type="library" bom-ref="pkg:npm/testdependency2@1.0.2"><name>testdependency2</name><version>1.0.2</version><purl>pkg:npm/testdependency2@1.0.2</purl></component><component type="library" bom-ref="pkg:npm/testdependency@1.0.0"><name>testdependency</name><version>1.0.0</version><purl>pkg:npm/testdependency@1.0.0</purl></component><component type="library" bom-ref="pkg:npm/%40scope/testdependency3@1.0.2"><group>@scope</group><name>testdependency3</name><version>1.0.2</version><purl>pkg:npm/%40scope/testdependency3@1.0.2</purl></component></components></bom>`;
 
 describe('CycloneDXSbomCreator', async () => {
   it('should create an sbom string given a minimal valid object', async () => {
@@ -64,5 +66,13 @@ describe('CycloneDXSbomCreator', async () => {
     const string = await sbomCreator.createBom(object);
 
     expect(string).to.eq(expectedResponse);
+  });
+
+  it('should create a spartan sbom string given a minimal valid object', async () => {
+    const sbomCreator = new CycloneDXSbomCreator(process.cwd(), { spartan: true });
+
+    const string = await sbomCreator.createBom(object);
+
+    expect(string).to.eq(expectedSpartanResponse);
   });
 });

--- a/src/CycloneDX/CycloneDXSbomCreator.ts
+++ b/src/CycloneDX/CycloneDXSbomCreator.ts
@@ -52,7 +52,7 @@ export class CycloneDXSbomCreator {
 
   readonly SBOMSCHEMA: string = 'http://cyclonedx.org/schema/bom/1.1';
 
-  constructor(readonly path: string, readonly options?: Options) { }
+  constructor(readonly path: string, readonly options?: Options) {}
 
   public async createBom(pkgInfo: any): Promise<string> {
     const bom = builder.create('bom', { encoding: 'utf-8', separateArrayItems: true }).att('xmlns', this.SBOMSCHEMA);
@@ -116,9 +116,9 @@ export class CycloneDXSbomCreator {
       const name: string = pkgIdentifier.fullName as string;
       const version: string = pkg.version as string;
       const purl: string = toPurl(name, version, group);
-      let component: Component = {} as any;
-      component["@bom-ref"] = purl;
-      component["@type"] = this.determinePackageType(pkg);
+      const component: Component = {} as any;
+      component['@bom-ref'] = purl;
+      component['@type'] = this.determinePackageType(pkg);
       component.purl = purl;
       component.group = group;
       component.name = name;

--- a/src/CycloneDX/Options.ts
+++ b/src/CycloneDX/Options.ts
@@ -18,4 +18,5 @@ export interface Options {
   includeBomSerialNumber?: boolean;
   includeLicenseData?: boolean;
   includeLicenseText?: boolean;
+  spartan?: boolean;
 }

--- a/src/CycloneDX/Types/Component.ts
+++ b/src/CycloneDX/Types/Component.ts
@@ -13,23 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ExternalReference } from "./ExternalReference";
-import { Hash } from "./Hash";
+import { ExternalReference } from './ExternalReference';
+import { Hash } from './Hash';
 
 export interface Component {
-  '@type': string,
-  '@bom-ref': string,
-  group: string,
-  name: string,
-  version: string,
-  description: Object,
-  hashes?: Array<Hash>,
-  licenses?: Array<any>,
-  purl: string,
-  externalReferences?: Array<ExternalReference>
+  '@type': string;
+  '@bom-ref': string;
+  group: string;
+  name: string;
+  version: string;
+  description?: Object;
+  hashes?: Array<Hash>;
+  licenses?: Array<any>;
+  purl: string;
+  externalReferences?: Array<ExternalReference>;
 }
 
 export interface GenericDescription {
-  '#cdata': string,
-  '@content-type'?: string
+  '#cdata': string;
+  '@content-type'?: string;
 }


### PR DESCRIPTION
Allow for a more sparse SBOM to be created

This pull request makes the following changes:
* Adds a spartan option to the SBOM creator
* Only fills out the details if we want them to be, otherwise creates a minimal sbom with what I thik are the required fields

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
