### PR TITLE
Add support of proxy environment variable (#191)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,11 +2,13 @@ A lot of awesome people have contributed to this project! Here they are:
 
 Sonatype internal people:
 
-* [@ken-duck](https://github.com/ken-duck/) (Ken Duck)
-* [@DarthHater](https://github.com/darthhater/) (Jeffry Hesse)
-* [@allenhsieh](https://github.com/allenhsieh) (Allen Hsieh)
-* [@ajurgenson55](https://github.com/ajurgenson55) (Artie)
+- [@ken-duck](https://github.com/ken-duck/) (Ken Duck)
+- [@DarthHater](https://github.com/darthhater/) (Jeffry Hesse)
+- [@allenhsieh](https://github.com/allenhsieh) (Allen Hsieh)
+- [@ajurgenson55](https://github.com/ajurgenson55) (Artie)
 
 External contributors:
+
+- [@francois-roget](https://github.com/francois-roget) (François Roget) for [Ingenico Group](https://github.com/ingenico-group)
 
 Possibly You!

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ We've provided an example repo with a working TravisCI config on a "fake" but re
 
 We've provided an example repo with a working GitHub Action on a "fake" but real project, you can see how it is all setup by clicking [this link](https://github.com/sonatype-nexus-community/example-auditjs-repo#usage-with-github-actions).
 
+#### Proxy integration
+
+The tool reads the `http_proxy` or `https_proxy` environment variables to perform network request through a Proxy.
+
 ### Usage As A NPM Script
 
 `auditjs` can be added as a devDependency to your project, and then an npm script can be added so you can leverage it in your npm scripts.
@@ -291,9 +295,9 @@ We care a lot about making the world a safer place, and that's why we continue t
 
 Remember:
 
-* If you are a Sonatype customer, you may file Sonatype support tickets related to `AuditJS` support in regard to this project
-  * We suggest you file issues here on GitHub as well, so that the community can pitch in
-* If you are not a Sonatype customer, Do NOT file Sonatype support tickets related to nancy support in regard to this project, file an issue here on GitHub
+- If you are a Sonatype customer, you may file Sonatype support tickets related to `AuditJS` support in regard to this project
+  - We suggest you file issues here on GitHub as well, so that the community can pitch in
+- If you are not a Sonatype customer, Do NOT file Sonatype support tickets related to nancy support in regard to this project, file an issue here on GitHub
 
 Have fun creating and using `AuditJS` and the [Sonatype OSS Index](https://ossindex.sonatype.org/), we are glad to have you here!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,6 +549,24 @@
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.tunz.com/artifactory/api/npm/npm/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha1-XQEB8Zu/rtOZgLIq6GbeFTuT8Jo=",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://artifactory.tunz.com/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -1546,6 +1564,25 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
       "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.tunz.com/artifactory/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://artifactory.tunz.com/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "chalk": "^3.0.0",
     "colors": "^1.3.1",
     "figlet": "^1.2.4",
+    "https-proxy-agent": "^5.0.0",
     "js-yaml": "3.13.1",
     "log4js": "^6.1.2",
     "node-fetch": "^2.6.0",

--- a/src/Services/IqRequestService.ts
+++ b/src/Services/IqRequestService.ts
@@ -48,6 +48,7 @@ export class IqRequestService {
     const response = await fetch(`${this.host}${APPLICATION_INTERNAL_ID_ENDPOINT}${this.application}`, {
       method: 'get',
       headers: [this.getBasicAuth(), RequestHelpers.getUserAgent()],
+      agent: RequestHelpers.getHttpAgent(),
     });
     if (response.ok) {
       const res = await response.json();
@@ -81,6 +82,7 @@ export class IqRequestService {
         method: 'post',
         headers: [this.getBasicAuth(), RequestHelpers.getUserAgent(), ['Content-Type', 'application/xml']],
         body: data,
+        agent: RequestHelpers.getHttpAgent(),
       },
     );
     if (response.ok) {
@@ -107,6 +109,7 @@ export class IqRequestService {
       const response = await fetch(mergeUrl.href, {
         method: 'get',
         headers: [this.getBasicAuth(), RequestHelpers.getUserAgent()],
+        agent: RequestHelpers.getHttpAgent(),
       });
 
       const body = response.ok;

--- a/src/Services/OssIndexRequestService.ts
+++ b/src/Services/OssIndexRequestService.ts
@@ -60,6 +60,7 @@ export class OssIndexRequestService {
       method: 'post',
       body: JSON.stringify(data),
       headers: this.getHeaders(),
+      agent: RequestHelpers.getHttpAgent(),
     })
       .then(this.checkStatus)
       .then((res) => res.json())

--- a/src/Services/RequestHelpers.spec.ts
+++ b/src/Services/RequestHelpers.spec.ts
@@ -16,6 +16,7 @@
 import expect from '../Tests/TestHelper';
 import { RequestHelpers } from './RequestHelpers';
 import os from 'os';
+
 const pack = require('../../package.json');
 
 describe('RequestHelpers', () => {
@@ -28,5 +29,28 @@ describe('RequestHelpers', () => {
     const expected = ['User-Agent', `AuditJS/${pack.version} (${environment} ${environmentVersion}; ${system})`];
 
     expect(res).to.include.members(expected);
+  });
+
+  it('should return an httpAgent when env variable is set', () => {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    process.env.http_proxy = 'http://test.local:8080';
+    const res = RequestHelpers.getHttpAgent();
+    expect(res).not.to.be.undefined;
+    if (res) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      expect(res.proxy.host).to.equal('test.local');
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      expect(res.proxy.port).to.equal(8080);
+    }
+  });
+
+  it('should return undefined when no env variable is set', () => {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    process.env.http_proxy = 'no-proxy';
+
+    const res = RequestHelpers.getHttpAgent();
+    expect(res).to.be.undefined;
   });
 });

--- a/src/Services/RequestHelpers.ts
+++ b/src/Services/RequestHelpers.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import os from 'os';
+import { Agent } from 'http';
+const HttpsProxyAgent = require('https-proxy-agent');
 const pack = require('../../package.json');
 
 export class RequestHelpers {
@@ -24,5 +26,13 @@ export class RequestHelpers {
     const system = `${os.type()} ${os.release()}`;
 
     return ['User-Agent', `AuditJS/${pack.version} (${environment} ${environmentVersion}; ${system})`];
+  }
+
+  public static getHttpAgent(): Agent | undefined {
+    const proxyUrl = process.env.http_proxy || process.env.https_proxy;
+    if (proxyUrl !== undefined && proxyUrl !== 'no-proxy') {
+      return new HttpsProxyAgent(proxyUrl);
+    }
+    return undefined;
   }
 }

--- a/src/Services/RequestHelpers.ts
+++ b/src/Services/RequestHelpers.ts
@@ -15,7 +15,7 @@
  */
 import os from 'os';
 import { Agent } from 'http';
-const HttpsProxyAgent = require('https-proxy-agent');
+import { HttpsProxyAgent } from 'https-proxy-agent';
 const pack = require('../../package.json');
 
 export class RequestHelpers {


### PR DESCRIPTION
Allow the CLI to take into account http_proxy or https_proxy environment varaibles to perform the network requests. This is particularly handy in corporate CI.

This pull request makes the following changes:
* Add a getHttpAgent method in RequestHelpers to get a configured http.Agent (or undefined)
* Use this http.Agent for all fetch calls.
* Test the http.Agent generation in RequestHelpers.spec

It relates to the following issue #s:
* Fixes #191 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
