### PR TITLE
Bump version of node-persist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,16 +2216,19 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
       }
     },
     "mocha": {
@@ -2586,12 +2589,9 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-persist": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-3.0.5.tgz",
-      "integrity": "sha512-zJmBA58kI9QAxXLMc4NLswgzXVIqKfsfQtiySMF6eEQ3kVvoM3YHzcP0//L9u30Fqx3cYe1FL/a+fyB3VwO/oQ==",
-      "requires": {
-        "mkdirp": "~0.5.1"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-3.1.0.tgz",
+      "integrity": "sha512-/j+fd/u71wNgKf3V2bx4tnDm+3GvLnlCuvf2MXbJ3wern+67IAb6zN9Leu1tCWPlPNZ+v1hLSibVukkPK2HqJw=="
     },
     "node-preload": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "js-yaml": "3.13.1",
     "log4js": "^6.1.2",
     "node-fetch": "^2.6.0",
-    "node-persist": "^3.0.5",
+    "node-persist": "^3.1.0",
     "ora": "^4.0.3",
     "read-installed": "~4.0.3",
     "spdx-license-ids": "^3.0.5",


### PR DESCRIPTION
Thanks to: https://github.com/simonlast/node-persist/issues/123 we can bump node-persist and get away from an upstream vulnerability in `minimist`

This pull request makes the following changes:
* Bumps version to `3.1.0` for `node-persist`
* Ran `npm i`, audited with IQ

It relates to the following issue #s:
* Fixes #X

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
