### PR TITLE
Add failure notifications and tweak the test results ant glob.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ dockerizedBuildPipeline(
       }
     })
   },
-  testResults: [ '**/reports/test-*.xml' ],
+  testResults: [ 'reports/test-results.xml' ],
   onSuccess: {
     githubStatusUpdate('success')
   },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,11 +35,13 @@ dockerizedBuildPipeline(
       }
     })
   },
-  testResults: [ 'reports/test-results.xml' ],
+  testResults: [ '**/reports/test-*.xml' ],
   onSuccess: {
     githubStatusUpdate('success')
   },
   onFailure: {
     githubStatusUpdate('failure')
+    notifyChat(currentBuild: currentBuild, env: env, room: 'community-oss-fun')
+    sendEmailNotification(currentBuild, env, [], 'community-group@sonatype.com')
   }
 )


### PR DESCRIPTION
No one knows when Jenkins fails, this fixes that. 

This pull request makes the following changes:
* Adds notification failure notification


cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
