### PR TITLE
Bump version of node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2584,9 +2584,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-persist": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "https-proxy-agent": "^5.0.0",
     "js-yaml": "3.13.1",
     "log4js": "^6.1.2",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "node-persist": "^3.1.0",
     "ora": "^4.0.3",
     "read-installed": "~4.0.3",


### PR DESCRIPTION
Node-Fetch pre 2.6.0 is vulnerable, 2.6.1 is not! EASY!

This pull request makes the following changes:
* Bumps dep for node-fetch to 2.6.1 in package.json
* `npm i`
* ????
* PROFIT!!!!

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
