### PR TITLE
SEND SOME Hash hash hash to IQ

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch with Nexus IQ Server",
-      "args": ["iq", "-a", "auditjs"],
+      "args": ["iq", "-a", "testapp", "-g", "bin"],
       "program": "${workspaceFolder}/src/index.ts",
       "preLaunchTask": "tsc: build - tsconfig.json",
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch with Nexus IQ Server",
-      "args": ["iq", "-a", "testapp", "-g", "bin"],
+      "args": ["iq", "-a", "testapp"],
       "program": "${workspaceFolder}/src/index.ts",
       "preLaunchTask": "tsc: build - tsconfig.json",
       "console": "integratedTerminal",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "type": "typescript",
+        "tsconfig": "tsconfig.json",
+        "problemMatcher": ["$tsc"],
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        }
+      }
+    ]
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,16 +314,16 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/elementtree": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@types/elementtree/-/elementtree-0.1.0.tgz",
+      "integrity": "sha512-EOSadl5+bw5i2umsJPXvCHSOXRlXha2et+2Wgdog66KbSVhT4pofRbSg6AbKkPEVO9mZusfcMZb5+HfJjpbLtA==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-      "dev": true
-    },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
     "@types/figlet": {
@@ -333,12 +333,11 @@
       "dev": true
     },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -972,6 +971,14 @@
         "esutils": "^2.0.2"
       }
     },
+    "elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha1-mskb5uUvtuYkTE5UpKw+2K6OKcA=",
+      "requires": {
+        "sax": "1.1.4"
+      }
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1477,9 +1484,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2318,6 +2325,20 @@
             "locate-path": "^3.0.0"
           }
         },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3094,6 +3115,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
   "devDependencies": {
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "7.1.1",
+    "@types/elementtree": "^0.1.0",
     "@types/figlet": "^1.2.0",
+    "@types/glob": "^7.1.3",
     "@types/js-yaml": "^3.12.2",
     "@types/mocha": "5.2.7",
     "@types/mock-fs": "^4.10.0",
@@ -86,7 +88,9 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "colors": "^1.3.1",
+    "elementtree": "^0.1.7",
     "figlet": "^1.2.4",
+    "glob": "^7.1.6",
     "https-proxy-agent": "^5.0.0",
     "js-yaml": "3.13.1",
     "log4js": "^6.1.2",

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -137,32 +137,33 @@ export class Application {
     }
   }
 
-  private getHashesFromPath(paths: Set<string>, basePath: string = '') {
-    let promises: any[] = [];
-    let hasher = new Hasher('sha1');
+  private getHashesFromPath(paths: Set<string>, basePath = '') {
+    const promises: any[] = [];
+    const hasher = new Hasher('sha1');
 
     paths.forEach((path) => {
       promises.push(hasher.getHashFromPath(join(process.cwd(), basePath, path)));
-    })
+    });
 
     return Promise.all(promises);
   }
 
-  private async populateCoordinatesForIQ(deepPath: string = ''): Promise<void> {
+  private async populateCoordinatesForIQ(deepPath = ''): Promise<void> {
     try {
       if (deepPath != '') {
         logMessage('Trying to get sbom from cyclonedx/bom and list of hashes from deepPath', DEBUG);
-        let files = Lister.getListOfFilesInBasePath(join(deepPath));
-        logMessage('Got list of files to get hashes from', DEBUG, {files: files});
+        const files = Lister.getListOfFilesInBasePath(join(deepPath));
+        logMessage('Got list of files to get hashes from', DEBUG, { files: files });
         logMessage('Attempting to generate sbom and get hashes', DEBUG);
-        await Promise.all([this.getHashesFromPath(files, deepPath), this.muncher.getSbomFromCommand()])
-        .then(async (values) => {
-          logMessage('Got sbom and hashes, attempting to merge them', DEBUG);
-          let merger = new Merger();
-          this.sbom = await merger.mergeHashesIntoSbom(values[0], values[1]);
-          logMessage('Sbom merged', DEBUG, {sbom: this.sbom});
-          logMessage('Merge of sbom and hashes successful, our work is done here', DEBUG);
-        });
+        await Promise.all([this.getHashesFromPath(files, deepPath), this.muncher.getSbomFromCommand()]).then(
+          async (values) => {
+            logMessage('Got sbom and hashes, attempting to merge them', DEBUG);
+            const merger = new Merger();
+            this.sbom = await merger.mergeHashesIntoSbom(values[0], values[1]);
+            logMessage('Sbom merged', DEBUG, { sbom: this.sbom });
+            logMessage('Merge of sbom and hashes successful, our work is done here', DEBUG);
+          },
+        );
       } else {
         logMessage('Trying to get sbom from cyclonedx/bom', DEBUG);
         this.sbom = await this.muncher.getSbomFromCommand();

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -32,6 +32,10 @@ import { filterVulnerabilities } from '../Whitelist/VulnerabilityExcluder';
 import { IqServerConfig } from '../Config/IqServerConfig';
 import { OssIndexServerConfig } from '../Config/OssIndexServerConfig';
 import { visuallySeperateText } from '../Visual/VisualHelper';
+import { Lister } from '../Hasher/Lister';
+import { join } from 'path';
+import { Merger } from '../Merger/Merger';
+import { Hasher } from '../Hasher/Hasher';
 const pj = require('../../package.json');
 
 export class Application {
@@ -74,7 +78,7 @@ export class Application {
       logMessage('Attempting to start application', DEBUG);
       logMessage('Getting coordinates for Sonatype IQ', DEBUG);
       this.spinner.maybeCreateMessageForSpinner('Getting coordinates for Sonatype IQ');
-      await this.populateCoordinatesForIQ();
+      await this.populateCoordinatesForIQ(args.deep);
       logMessage(`Coordinates obtained`, DEBUG, this.sbom);
 
       this.spinner.maybeSucceed();
@@ -133,11 +137,37 @@ export class Application {
     }
   }
 
-  private async populateCoordinatesForIQ(): Promise<void> {
+  private getHashesFromPath(paths: Set<string>, basePath: string = '') {
+    let promises: any[] = [];
+    let hasher = new Hasher('sha1');
+
+    paths.forEach((path) => {
+      promises.push(hasher.getHashFromPath(join(process.cwd(), basePath, path)));
+    })
+
+    return Promise.all(promises);
+  }
+
+  private async populateCoordinatesForIQ(deepPath: string = ''): Promise<void> {
     try {
-      logMessage('Trying to get sbom from cyclonedx/bom', DEBUG);
-      this.sbom = await this.muncher.getSbomFromCommand();
-      logMessage('Successfully got sbom from cyclonedx/bom', DEBUG);
+      if (deepPath != '') {
+        logMessage('Trying to get sbom from cyclonedx/bom and list of hashes from deepPath', DEBUG);
+        let files = Lister.getListOfFilesInBasePath(join(deepPath));
+        logMessage('Got list of files to get hashes from', DEBUG, {files: files});
+        logMessage('Attempting to generate sbom and get hashes', DEBUG);
+        await Promise.all([this.getHashesFromPath(files, deepPath), this.muncher.getSbomFromCommand()])
+        .then(async (values) => {
+          logMessage('Got sbom and hashes, attempting to merge them', DEBUG);
+          let merger = new Merger();
+          this.sbom = await merger.mergeHashesIntoSbom(values[0], values[1]);
+          logMessage('Sbom merged', DEBUG, {sbom: this.sbom});
+          logMessage('Merge of sbom and hashes successful, our work is done here', DEBUG);
+        });
+      } else {
+        logMessage('Trying to get sbom from cyclonedx/bom', DEBUG);
+        this.sbom = await this.muncher.getSbomFromCommand();
+        logMessage('Successfully got sbom from cyclonedx/bom', DEBUG);
+      }
     } catch (e) {
       logMessage(`An error was encountered while gathering your dependencies into an SBOM`, ERROR, {
         title: e.message,

--- a/src/Hasher/Hasher.spec.ts
+++ b/src/Hasher/Hasher.spec.ts
@@ -23,29 +23,28 @@ const json2 = `{"anotherThing": "anotherValue"}`;
 
 const json3 = `{"yetAnotherThing": "yetAnotherValue"}`;
 
-describe("Hasher", () => {
-  it("should return a sha1 hash for a provided path", async () => {
-    mock({'/nonsensical': {
-      'auditjs.js': json,
-      'directory': {
-        'anotherpath.js': json2,
-        'fakething.js': json3,
-        'anotherdirectory': {}
-        }
-      } 
+describe('Hasher', () => {
+  it('should return a sha1 hash for a provided path', async () => {
+    mock({
+      '/nonsensical': {
+        'auditjs.js': json,
+        directory: {
+          'anotherpath.js': json2,
+          'fakething.js': json3,
+          anotherdirectory: {},
+        },
+      },
     });
 
-    let expected = '54bbc009e6ba2ee4e892a0347279819bd30e5e29';
+    const expected = '54bbc009e6ba2ee4e892a0347279819bd30e5e29';
 
-    let hasher = new Hasher('sha1');
+    const hasher = new Hasher('sha1');
 
-    let result = await hasher.getHashFromPath('/nonsensical/auditjs.js');
+    const result = await hasher.getHashFromPath('/nonsensical/auditjs.js');
 
-    expect(result.hash)
-      .to.eq(expected);
+    expect(result.hash).to.eq(expected);
 
-    expect(result.path)
-      .to.eq('/nonsensical/auditjs.js');
+    expect(result.path).to.eq('/nonsensical/auditjs.js');
 
     mock.restore();
   });

--- a/src/Hasher/Hasher.spec.ts
+++ b/src/Hasher/Hasher.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import expect from '../Tests/TestHelper';
+import { Hasher } from './Hasher';
+import mock from 'mock-fs';
+
+const json = `{"thing": "value"}`;
+
+const json2 = `{"anotherThing": "anotherValue"}`;
+
+const json3 = `{"yetAnotherThing": "yetAnotherValue"}`;
+
+describe("Hasher", () => {
+  it("should return a sha1 hash for a provided path", async () => {
+    mock({'/nonsensical': {
+      'auditjs.js': json,
+      'directory': {
+        'anotherpath.js': json2,
+        'fakething.js': json3,
+        'anotherdirectory': {}
+        }
+      } 
+    });
+
+    let expected = '54bbc009e6ba2ee4e892a0347279819bd30e5e29';
+
+    let hasher = new Hasher('sha1');
+
+    let result = await hasher.getHashFromPath('/nonsensical/auditjs.js');
+
+    expect(result.hash)
+      .to.eq(expected);
+
+    expect(result.path)
+      .to.eq('/nonsensical/auditjs.js');
+
+    mock.restore();
+  });
+});

--- a/src/Hasher/Hasher.ts
+++ b/src/Hasher/Hasher.ts
@@ -23,8 +23,8 @@ export class Hasher {
 
   public getHashFromPath(path: string): Promise<HashCoordinate> {
     return new Promise((resolve, reject) => {
-      let fd = fs.createReadStream(path);
-      let hash = crypto.createHash(this.algorithm);
+      const fd = fs.createReadStream(path);
+      const hash = crypto.createHash(this.algorithm);
       hash.setEncoding('hex');
 
       fd.on('end', () => {

--- a/src/Hasher/Hasher.ts
+++ b/src/Hasher/Hasher.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import crypto from 'crypto';
+import { HashCoordinate } from '../Types/HashCoordinate';
+
+export class Hasher {
+  constructor(readonly algorithm: string = 'sha1') {}
+
+  public getHashFromPath(path: string): Promise<HashCoordinate> {
+    return new Promise((resolve, reject) => {
+      let fd = fs.createReadStream(path);
+      let hash = crypto.createHash(this.algorithm);
+      hash.setEncoding('hex');
+
+      fd.on('end', () => {
+        hash.end();
+        resolve(new HashCoordinate(hash.read(), path));
+      });
+
+      fd.on('error', (err) => {
+        reject(err);
+      });
+
+      fd.pipe(hash);
+    });
+  }
+}

--- a/src/Hasher/Lister.spec.ts
+++ b/src/Hasher/Lister.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import expect from '../Tests/TestHelper';
+import { Lister } from './Lister';
+import mock from 'mock-fs';
+
+describe("Lister", () => {
+  it("should return a set of paths to js files and no directories given a base path", async () => {
+    mock({'/nonsensical': {
+      'auditjs.js': '{}',
+      'directory': {
+        'anotherpath.js': '{}',
+        'fakething.notjs': '{}',
+        'anotherdirectory': {}
+        }
+      } 
+    });
+
+    let expected = new Set();
+
+    expected.add('auditjs.js');
+    expected.add('directory/anotherpath.js');
+
+    let result = Lister.getListOfFilesInBasePath('/nonsensical');
+
+    expect(result)
+      .to.deep.eq(expected);
+
+    mock.restore();
+  });
+});

--- a/src/Hasher/Lister.spec.ts
+++ b/src/Hasher/Lister.spec.ts
@@ -17,27 +17,27 @@ import expect from '../Tests/TestHelper';
 import { Lister } from './Lister';
 import mock from 'mock-fs';
 
-describe("Lister", () => {
-  it("should return a set of paths to js files and no directories given a base path", async () => {
-    mock({'/nonsensical': {
-      'auditjs.js': '{}',
-      'directory': {
-        'anotherpath.js': '{}',
-        'fakething.notjs': '{}',
-        'anotherdirectory': {}
-        }
-      } 
+describe('Lister', () => {
+  it('should return a set of paths to js files and no directories given a base path', async () => {
+    mock({
+      '/nonsensical': {
+        'auditjs.js': '{}',
+        directory: {
+          'anotherpath.js': '{}',
+          'fakething.notjs': '{}',
+          anotherdirectory: {},
+        },
+      },
     });
 
-    let expected = new Set();
+    const expected = new Set();
 
     expected.add('auditjs.js');
     expected.add('directory/anotherpath.js');
 
-    let result = Lister.getListOfFilesInBasePath('/nonsensical');
+    const result = Lister.getListOfFilesInBasePath('/nonsensical');
 
-    expect(result)
-      .to.deep.eq(expected);
+    expect(result).to.deep.eq(expected);
 
     mock.restore();
   });

--- a/src/Hasher/Lister.ts
+++ b/src/Hasher/Lister.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import glob from 'glob';
+
+export abstract class Lister {
+  public static getListOfFilesInBasePath(path: string): Set<string> {
+    let files = glob.sync(`**/*.js`, {nodir: true, cwd: path});
+
+    return new Set(files);
+  }
+}

--- a/src/Hasher/Lister.ts
+++ b/src/Hasher/Lister.ts
@@ -17,7 +17,7 @@ import glob from 'glob';
 
 export abstract class Lister {
   public static getListOfFilesInBasePath(path: string): Set<string> {
-    let files = glob.sync(`**/*.js`, {nodir: true, cwd: path});
+    const files = glob.sync(`**/*.js`, { nodir: true, cwd: path });
 
     return new Set(files);
   }

--- a/src/Merger/Merger.spec.ts
+++ b/src/Merger/Merger.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import expect from '../Tests/TestHelper';
+import { Merger } from './Merger';
+import { HashCoordinate } from '../Types/HashCoordinate';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+let hashes = new Array<HashCoordinate>();
+
+hashes.push(new HashCoordinate("hash", "path"));
+hashes.push(new HashCoordinate("hash1", "path1"));
+hashes.push(new HashCoordinate("hash2", "path2"));
+hashes.push(new HashCoordinate("hash3", "path3"));
+
+describe("Merger", () => {
+  it("should take an array of HashCoordinates and merge them together with the existing XML SBOM", async () => {
+    let sbom = readFileSync(join(__dirname, 'validsbom.xml'), 'utf8').toString();
+
+    let merger = new Merger();
+
+    let results = await merger.mergeHashesIntoSbom(hashes, sbom);
+
+    expect(results).to.include(`<name>path</name>`);
+    expect(results).to.include(`<hashes><hash alg="SHA-1">hash</hash></hashes>`);
+    expect(results).to.include(`<name>path3</name>`);
+    expect(results).to.include(`<hashes><hash alg="SHA-1">hash3</hash></hashes>`);
+  });
+
+  it("should not merge an array of HashCoordinates with an invalid XML SBOM", () => {
+    let sbom = "this is garbage data";
+    
+    let merger = new Merger();
+
+    let results = merger.mergeHashesIntoSbom(hashes, sbom);
+
+    expect(results).to.eventually.be.rejected;
+  });
+});

--- a/src/Merger/Merger.spec.ts
+++ b/src/Merger/Merger.spec.ts
@@ -19,20 +19,20 @@ import { HashCoordinate } from '../Types/HashCoordinate';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-let hashes = new Array<HashCoordinate>();
+const hashes = new Array<HashCoordinate>();
 
-hashes.push(new HashCoordinate("hash", "path"));
-hashes.push(new HashCoordinate("hash1", "path1"));
-hashes.push(new HashCoordinate("hash2", "path2"));
-hashes.push(new HashCoordinate("hash3", "path3"));
+hashes.push(new HashCoordinate('hash', 'path'));
+hashes.push(new HashCoordinate('hash1', 'path1'));
+hashes.push(new HashCoordinate('hash2', 'path2'));
+hashes.push(new HashCoordinate('hash3', 'path3'));
 
-describe("Merger", () => {
-  it("should take an array of HashCoordinates and merge them together with the existing XML SBOM", async () => {
-    let sbom = readFileSync(join(__dirname, 'validsbom.xml'), 'utf8').toString();
+describe('Merger', () => {
+  it('should take an array of HashCoordinates and merge them together with the existing XML SBOM', async () => {
+    const sbom = readFileSync(join(__dirname, 'validsbom.xml'), 'utf8').toString();
 
-    let merger = new Merger();
+    const merger = new Merger();
 
-    let results = await merger.mergeHashesIntoSbom(hashes, sbom);
+    const results = await merger.mergeHashesIntoSbom(hashes, sbom);
 
     expect(results).to.include(`<name>path</name>`);
     expect(results).to.include(`<hashes><hash alg="SHA-1">hash</hash></hashes>`);
@@ -40,12 +40,12 @@ describe("Merger", () => {
     expect(results).to.include(`<hashes><hash alg="SHA-1">hash3</hash></hashes>`);
   });
 
-  it("should not merge an array of HashCoordinates with an invalid XML SBOM", () => {
-    let sbom = "this is garbage data";
-    
-    let merger = new Merger();
+  it('should not merge an array of HashCoordinates with an invalid XML SBOM', () => {
+    const sbom = 'this is garbage data';
 
-    let results = merger.mergeHashesIntoSbom(hashes, sbom);
+    const merger = new Merger();
+
+    const results = merger.mergeHashesIntoSbom(hashes, sbom);
 
     expect(results).to.eventually.be.rejected;
   });

--- a/src/Merger/Merger.ts
+++ b/src/Merger/Merger.ts
@@ -17,27 +17,26 @@ import elementtree from 'elementtree';
 import { HashCoordinate } from '../Types/HashCoordinate';
 
 export class Merger {
-
   constructor(readonly algorithm: string = 'SHA-1') {}
 
   public async mergeHashesIntoSbom(hashes: HashCoordinate[], xml: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      let tree = elementtree.parse(xml);
-      let components = tree.find('./components');
+      const tree = elementtree.parse(xml);
+      const components = tree.find('./components');
       if (!components) {
         reject();
       }
       hashes.map((val) => {
         if (components) {
-          let component = elementtree.SubElement(components, 'component', {'type': 'library'});
-          let name = elementtree.SubElement(component, 'name');
+          const component = elementtree.SubElement(components, 'component', { type: 'library' });
+          const name = elementtree.SubElement(component, 'name');
           name.text = val.path;
-          let version = elementtree.SubElement(component, 'version');
-          version.text = "0";
-          let hashes = elementtree.SubElement(component, 'hashes');
-          let hash = elementtree.SubElement(hashes, 'hash', {'alg': this.algorithm});
+          const version = elementtree.SubElement(component, 'version');
+          version.text = '0';
+          const hashes = elementtree.SubElement(component, 'hashes');
+          const hash = elementtree.SubElement(hashes, 'hash', { alg: this.algorithm });
           hash.text = val.hash;
-        } 
+        }
       });
       resolve(tree.write());
     });

--- a/src/Merger/Merger.ts
+++ b/src/Merger/Merger.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import elementtree from 'elementtree';
+import { HashCoordinate } from '../Types/HashCoordinate';
+
+export class Merger {
+
+  constructor(readonly algorithm: string = 'SHA-1') {}
+
+  public async mergeHashesIntoSbom(hashes: HashCoordinate[], xml: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let tree = elementtree.parse(xml);
+      let components = tree.find('./components');
+      if (!components) {
+        reject();
+      }
+      hashes.map((val) => {
+        if (components) {
+          let component = elementtree.SubElement(components, 'component', {'type': 'library'});
+          let name = elementtree.SubElement(component, 'name');
+          name.text = val.path;
+          let version = elementtree.SubElement(component, 'version');
+          version.text = "0";
+          let hashes = elementtree.SubElement(component, 'hashes');
+          let hash = elementtree.SubElement(hashes, 'hash', {'alg': this.algorithm});
+          hash.text = val.hash;
+        } 
+      });
+      resolve(tree.write());
+    });
+  }
+}

--- a/src/Merger/validsbom.xml
+++ b/src/Merger/validsbom.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='utf-8'?>
+<bom serialNumber="urn:uuid:df78599d-bf9b-43c7-b7df-d788e127555b" version="1"
+	xmlns="http://cyclonedx.org/schema/bom/1.1">
+	<components>
+		<component type="library">
+			<group>cyclonedx</group>
+			<name>bom</name>
+			<version>1.0.4</version>
+			<description>Creates CycloneDX Software Bill-of-Materials (SBoM) from Node.js projects</description>
+			<hashes>
+				<hash alg="SHA-512">3fa518448a9a7e4ee6923ffb60c5998cd9e54718b61b3d1b7e0f02543371ff6550f10e58499b3e5f60029fa97f87a9cb679fcaec6b291835ceb40d6221e9da4e</hash>
+			</hashes>
+			<licenses>
+				<license>
+					<id>Apache-2.0</id>
+					<text>\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      "License" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      "Licensor" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      "Legal Entity" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      "control" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      "You" (or "Your") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      "Source" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      "Object" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      "Work" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      "Derivative Works" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      "Contribution" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, "submitted"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as "Not a Contribution."\n\n      "Contributor" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a "NOTICE" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an "AS IS" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets "{}"\n      replaced with your own identifying information. (Don\'t include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same "printed page" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright {yyyy} {name of copyright owner}\n\n   Licensed under the Apache License, Version 2.0 (the "License");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an "AS IS" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n</text>
+				</license>
+			</licenses>
+			<purl>pkg:npm/%40cyclonedx/bom@1.0.4</purl>
+			<externalReferences>
+				<reference type="website">
+					<url>http://github.com/CycloneDX/cyclonedx-node-module</url>
+				</reference>
+				<reference type="issue-tracker">
+					<url>https://github.com/CycloneDX/cyclonedx-node-module/issues</url>
+				</reference>
+				<reference type="vcs">
+					<url>git+https://github.com/CycloneDX/cyclonedx-node-module.git</url>
+				</reference>
+			</externalReferences>
+		</component>
+		<component type="library">
+			<name>parse-packagejson-name</name>
+			<version>1.0.1</version>
+			<description>Parse an npm package name and returns some mildly interesting details about it</description>
+			<hashes>
+				<hash alg="SHA-1">ab5b322cd38c87b4a01620683cca56ad74c006a0</hash>
+			</hashes>
+			<licenses>
+				<license>
+					<id>MIT</id>
+				</license>
+			</licenses>
+			<purl>pkg:npm/parse-packagejson-name@1.0.1</purl>
+			<externalReferences>
+				<reference type="website">
+					<url>https://github.com/keithamus/sort-object-keys#readme</url>
+				</reference>
+				<reference type="issue-tracker">
+					<url>https://github.com/keithamus/sort-object-keys/issues</url>
+				</reference>
+				<reference type="vcs">
+					<url>git+ssh://git@github.com/keithamus/parse-packagejson-name.git</url>
+				</reference>
+			</externalReferences>
+		</component>
+		<component type="library">
+			<name>prettify-xml</name>
+			<version>1.2.0</version>
+			<description>Pretty-print XML.</description>
+			<hashes>
+				<hash alg="SHA-1">46dcf1ee8a8d8b73db30b7e06ef26dc9cf3f6f18</hash>
+			</hashes>
+			<licenses>
+				<license>
+					<id>MIT</id>
+					<text>\nThe MIT License (MIT)\nCopyright (c) 2016 Jonathan Werner\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n</text>
+				</license>
+			</licenses>
+			<purl>pkg:npm/prettify-xml@1.2.0</purl>
+			<externalReferences>
+				<reference type="website">
+					<url>https://github.com/jonathanewerner/prettify-xml#readme</url>
+				</reference>
+				<reference type="issue-tracker">
+					<url>https://github.com/jonathanewerner/prettify-xml/issues</url>
+				</reference>
+				<reference type="vcs">
+					<url>git+https://github.com/jonathanewerner/prettify-xml.git</url>
+				</reference>
+			</externalReferences>
+		</component>
+	</components>
+</bom>

--- a/src/Types/HashCoordinate.ts
+++ b/src/Types/HashCoordinate.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 export class HashCoordinate {
-    constructor(readonly hash: string, readonly path: string) {}
+  constructor(readonly hash: string, readonly path: string) {}
 }

--- a/src/Types/HashCoordinate.ts
+++ b/src/Types/HashCoordinate.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class HashCoordinate {
+    constructor(readonly hash: string, readonly path: string) {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,12 @@ let argv = yargs
         description: 'Specify IQ server url/port',
         demandOption: false,
       },
+      deep: {
+        alias: 'g',
+        type: 'string',
+        description: 'Specify path to do a deep scan of all .js files in a specific directory',
+        demandOption: false
+      },
       timeout: {
         alias: 't',
         type: 'number',


### PR DESCRIPTION
Welp, why not send in a list of hashes, if people want to do that!

This allows someone to scan for situations where someone may have copied a downloaded file of jquery, etc... into their project, and bypassed using npm or yarn to manage it as a dependency (it happens!)

This pull request makes the following changes:
* Adds `Hasher`, `Lister` and `Merger` classes, that hash files, list that they exist, and merges these files with an SBOM that is based on your declared dependencies
* Adds tests (thanks @allenhsieh !)
* Implements with a `-g <path>` or `--deep <path>` command line option

A test for this would be to create a `garbage` or etc... folder and pop a known vulnerable version of `jquery` or library of your choice into it. I used this file: https://code.jquery.com/jquery-1.12.4.min.js

Scan like so `npm run start iq -- --application <your-application> --deep garbage`

If all goes swimmingly, you should see this version of jQuery in your IQ report

I'd like to soft release this (not update docs), so people can play with it before we full bore announce it (I'd love to see how it helps overall)

This was based on #142, which was based off alpha, so I patched it over to new trunk.

It relates to the following issue #s:
* Fixes #142 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck / @ButterB0wl 
