### PR TITLE
Adds insecure flag, implements

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -276,6 +276,7 @@ export class Application {
       args.application as string,
       args.stage as string,
       args.timeout as number,
+      args.insecure as boolean,
     );
   }
 }

--- a/src/Services/IqRequestService.spec.ts
+++ b/src/Services/IqRequestService.spec.ts
@@ -29,7 +29,7 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(404, applicationInternalIdResponse.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300);
+    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.be.rejected;
@@ -42,7 +42,7 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(applicationInternalIdResponse.statusCode, { thereisnoid: 'none' });
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300);
+    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.be.rejectedWith(
@@ -66,7 +66,7 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(applicationInternalIdResponse.statusCode, applicationInternalIdResponse.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300);
+    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.equal(
@@ -90,7 +90,7 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(applicationInternalIdResponse.statusCode, applicationInternalIdResponse.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300);
+    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.be.rejectedWith(
@@ -113,7 +113,7 @@ describe('IQRequestService', () => {
       .get(`/api/v2/scan/applications/a20bc16e83944595a94c2e36c1cd228e/status/9cee2b6366fc4d328edc318eae46b2cb`)
       .reply(response.statusCode, response.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300);
+    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
 
     requestService.asyncPollForResults(
       'api/v2/scan/applications/a20bc16e83944595a94c2e36c1cd228e/status/9cee2b6366fc4d328edc318eae46b2cb',

--- a/src/Services/IqRequestService.spec.ts
+++ b/src/Services/IqRequestService.spec.ts
@@ -29,7 +29,15 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(404, applicationInternalIdResponse.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
+    const requestService = new IqRequestService(
+      'admin',
+      'admin123',
+      'http://testlocation:8070',
+      'testapp',
+      stage,
+      300,
+      false,
+    );
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.be.rejected;
@@ -42,7 +50,15 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(applicationInternalIdResponse.statusCode, { thereisnoid: 'none' });
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
+    const requestService = new IqRequestService(
+      'admin',
+      'admin123',
+      'http://testlocation:8070',
+      'testapp',
+      stage,
+      300,
+      false,
+    );
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.be.rejectedWith(
@@ -66,7 +82,15 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(applicationInternalIdResponse.statusCode, applicationInternalIdResponse.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
+    const requestService = new IqRequestService(
+      'admin',
+      'admin123',
+      'http://testlocation:8070',
+      'testapp',
+      stage,
+      300,
+      false,
+    );
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.equal(
@@ -90,7 +114,15 @@ describe('IQRequestService', () => {
       .get(`/api/v2/applications?publicId=testapp`)
       .reply(applicationInternalIdResponse.statusCode, applicationInternalIdResponse.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
+    const requestService = new IqRequestService(
+      'admin',
+      'admin123',
+      'http://testlocation:8070',
+      'testapp',
+      stage,
+      300,
+      false,
+    );
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
 
     return expect(requestService.submitToThirdPartyAPI(coords)).to.eventually.be.rejectedWith(
@@ -113,7 +145,15 @@ describe('IQRequestService', () => {
       .get(`/api/v2/scan/applications/a20bc16e83944595a94c2e36c1cd228e/status/9cee2b6366fc4d328edc318eae46b2cb`)
       .reply(response.statusCode, response.body);
 
-    const requestService = new IqRequestService('admin', 'admin123', 'http://testlocation:8070', 'testapp', stage, 300, false);
+    const requestService = new IqRequestService(
+      'admin',
+      'admin123',
+      'http://testlocation:8070',
+      'testapp',
+      stage,
+      300,
+      false,
+    );
 
     requestService.asyncPollForResults(
       'api/v2/scan/applications/a20bc16e83944595a94c2e36c1cd228e/status/9cee2b6366fc4d328edc318eae46b2cb',

--- a/src/Services/IqRequestService.ts
+++ b/src/Services/IqRequestService.ts
@@ -32,6 +32,7 @@ export class IqRequestService {
     readonly application: string,
     readonly stage: string,
     readonly timeout: number,
+    readonly insecure: boolean,
   ) {}
 
   private async init(): Promise<void> {
@@ -49,7 +50,7 @@ export class IqRequestService {
     const response = await fetch(`${this.host}${APPLICATION_INTERNAL_ID_ENDPOINT}${this.application}`, {
       method: 'get',
       headers: [this.getBasicAuth(), RequestHelpers.getUserAgent()],
-      agent: RequestHelpers.getHttpAgent(),
+      agent: RequestHelpers.getAgent(this.insecure),
     });
     if (response.ok) {
       const res = await response.json();
@@ -83,7 +84,7 @@ export class IqRequestService {
         method: 'post',
         headers: [this.getBasicAuth(), RequestHelpers.getUserAgent(), ['Content-Type', 'application/xml']],
         body: data,
-        agent: RequestHelpers.getHttpAgent(),
+        agent: RequestHelpers.getAgent(this.insecure),
       },
     );
     if (response.ok) {
@@ -110,7 +111,7 @@ export class IqRequestService {
       const response = await fetch(mergeUrl.href, {
         method: 'get',
         headers: [this.getBasicAuth(), RequestHelpers.getUserAgent()],
-        agent: RequestHelpers.getHttpAgent(),
+        agent: RequestHelpers.getAgent(this.insecure),
       });
 
       const body = response.ok;

--- a/src/Services/RequestHelpers.ts
+++ b/src/Services/RequestHelpers.ts
@@ -30,10 +30,10 @@ export class RequestHelpers {
     return ['User-Agent', `AuditJS/${pack.version} (${environment} ${environmentVersion}; ${system})`];
   }
 
-  public static getAgent(insecure: boolean = false): Agent | undefined {
+  public static getAgent(insecure = false): Agent | undefined {
     if (insecure) {
       return new HttpsAgent({
-        rejectUnauthorized: false
+        rejectUnauthorized: false,
       });
     }
 

--- a/src/Services/RequestHelpers.ts
+++ b/src/Services/RequestHelpers.ts
@@ -16,6 +16,7 @@
 
 import os from 'os';
 import { Agent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 const pack = require('../../package.json');
 
@@ -27,6 +28,16 @@ export class RequestHelpers {
     const system = `${os.type()} ${os.release()}`;
 
     return ['User-Agent', `AuditJS/${pack.version} (${environment} ${environmentVersion}; ${system})`];
+  }
+
+  public static getAgent(insecure: boolean = false): Agent | undefined {
+    if (insecure) {
+      return new HttpsAgent({
+        rejectUnauthorized: false
+      });
+    }
+
+    return this.getHttpAgent();
   }
 
   public static getHttpAgent(): Agent | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,11 @@ let argv = yargs
         description: 'Include Development Dependencies',
         demandOption: false,
       },
+      insecure: {
+        type: 'boolean',
+        description: 'Allow insecure connections',
+        demandOption: false,
+      },
     });
   })
   .command('config', 'Set config for OSS Index or Nexus IQ Server')


### PR DESCRIPTION
Allows for someone to ignore invalid SSL certs

This pull request makes the following changes:
* Implements a flag in `index.ts`
* Sends flag to `IqRequestService.ts`
* Implements a new `getAgent(insecure: boolean = false)` that will either get an insecure HTTPS Agent, or a Proxy Agent, or nothing if nothing is needed

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
