### PR TITLE
Fix #217: take whitelist path parameter into account

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -175,7 +175,7 @@ export class Application {
 
       this.spinner.maybeCreateMessageForSpinner('Removing whitelisted vulnerabilities');
       logMessage('Response being ran against whitelist', DEBUG, { ossIndexServerResults: ossIndexResults });
-      ossIndexResults = await filterVulnerabilities(ossIndexResults);
+      ossIndexResults = await filterVulnerabilities(ossIndexResults, args.whitelist);
       logMessage('Response has been whitelisted', DEBUG, { ossIndexServerResults: ossIndexResults });
       this.spinner.maybeSucceed();
 


### PR DESCRIPTION
The --whitelist parameter was not taken into account,, only the `auditjs.json` file in the current directory was.

This pull request makes the following changes:
* Pass the `args.whitelist` into the `filterVulnerabilities` method

Fixes:  #217

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
