### PR TITLE
Handle relative URLs

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -229,6 +229,8 @@ export class Application {
           const results: ReportStatus = Object.assign(new ReportStatus(), x);
           logMessage('Sonatype IQ results obtained!', DEBUG, results);
 
+          results.reportHtmlUrl = new URL(results.reportHtmlUrl!, requestService.host).href;
+
           const auditResults = new AuditIQServer();
 
           this.spinner.maybeStop();


### PR DESCRIPTION
This handles relative URLs

This pull request makes the following changes:
* Constructs a `new URL` using the reportHtmlUrl and the host for IQ Server, returns the `href` property for it

Approach stolen from: https://stackoverflow.com/a/16301947/338597

new URL will ignore the provided base if the first URL is absolute, voila!

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
