### PR TITLE
update ssri to fix CVE-2021-27290

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,11 +1282,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
-    },
     "figlet": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.2.4.tgz",
@@ -2180,6 +2175,14 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -3255,11 +3258,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "requires": {
-        "figgy-pudding": "^3.5.1"
+        "minipass": "^3.1.1"
       }
     },
     "streamroller": {
@@ -3694,6 +3697,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.1.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ora": "^4.0.3",
     "read-installed": "~4.0.3",
     "spdx-license-ids": "^3.0.5",
-    "ssri": "^6.0.0",
+    "ssri": "^8.0.1",
     "uuid": "^3.3.2",
     "xmlbuilder": "^13.0.2",
     "xmldom": "^0.5.0",


### PR DESCRIPTION
Fix CVE-2021-27290 found in ssri by IQ Server fast track (shameless plug).

I'm not sure about the development dependency: `"@types/ssri": "^6.0.1",` There is no version 8.0.1 of `@types/ssri` so I left it alone.

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
