### PR TITLE
Fix cache location configuration and expose option on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Options:
   --help           Show help                                           [boolean]
   --user, -u       Specify OSS Index username                           [string]
   --password, -p   Specify OSS Index password or token                  [string]
+  --cache, -c      Specify path to use as a cache location              [string]
   --quiet, -q      Only print out vulnerable dependencies              [boolean]
   --json, -j       Set output to JSON                                  [boolean]
   --xml, -x        Set output to JUnit XML format                      [boolean]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1550,7 +1550,7 @@
     "https-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -2317,10 +2317,9 @@
           }
         },
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-          "dev": true
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs": {
           "version": "16.2.0",
@@ -2335,6 +2334,14 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.8",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+              "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+              "dev": true
+            }
           }
         },
         "yargs-parser": {
@@ -2644,6 +2651,14 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.8",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+              "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+              "dev": true
+            }
           }
         },
         "yargs-parser": {
@@ -3705,12 +3720,6 @@
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
       "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
-    "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
-    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3731,9 +3740,9 @@
       },
       "dependencies": {
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "node": ">=8.0.0"
   },
   "resolutions": {
-    "hosted-git-info": "^3.0.8"
+    "hosted-git-info": "^3.0.8",
+    "y18n": "^5.0.8"
   },
   "scripts": {
     "preinstall": "npx npm-force-resolutions",

--- a/src/Application/Application.spec.ts
+++ b/src/Application/Application.spec.ts
@@ -1,0 +1,50 @@
+import expect from '../Tests/TestHelper';
+import { Application } from './Application';
+import sinon, { SinonStub } from 'sinon';
+import { OssIndexRequestService } from '../Services/OssIndexRequestService';
+import { Coordinates } from '../Types/Coordinates';
+import { OssIndexServerConfig } from '../Config/OssIndexServerConfig';
+import { TextFormatter } from '../Audit/Formatters/TextFormatter';
+
+describe('Application', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('merges both CLI and config options for auditWithOSSIndex, with CLI taking precedence', async () => {
+    const app = new Application(false, true);
+    const yargs = {
+      _: ['ossi'],
+      user: '',
+      password: 'cli-password',
+      cache: '',
+    };
+
+    sinon.stub(TextFormatter.prototype, 'printAuditResults');
+    sinon.stub(OssIndexServerConfig.prototype, 'getConfigFromFile');
+    sinon.stub(OssIndexServerConfig.prototype, 'getUsername').returns('config-user');
+    sinon.stub(OssIndexServerConfig.prototype, 'getToken').returns('config-password');
+    sinon.stub(OssIndexServerConfig.prototype, 'getCacheLocation').returns('config-cache-location');
+    let ossIndexRequestService: any = null;
+    sinon
+      .stub(OssIndexRequestService.prototype, 'callOSSIndexOrGetFromCache')
+      .callsFake(async function(this: any, data: Coordinates[], format = 'npm'): Promise<any> {
+        ossIndexRequestService = this;
+        return [
+          {
+            coordinates: '',
+            reference: '',
+            vulnerabilities: [],
+          },
+        ];
+      });
+    await app.startApplication(yargs);
+    sinon.assert.calledOnce(OssIndexRequestService.prototype.callOSSIndexOrGetFromCache as SinonStub);
+    expect(ossIndexRequestService).is.instanceOf(OssIndexRequestService);
+    if (ossIndexRequestService instanceof OssIndexRequestService) {
+      expect(ossIndexRequestService.user).to.equal('config-user');
+      expect(ossIndexRequestService.password).to.equal('cli-password');
+      expect(ossIndexRequestService.cacheLocation).to.equal('config-cache-location');
+    }
+  });
+});

--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -249,18 +249,18 @@ export class Application {
   }
 
   private getOssIndexRequestService(args: any): OssIndexRequestService {
-    if (args.user && args.password) {
-      return new OssIndexRequestService(args?.user, args?.password);
-    }
+    let config;
     try {
-      const config = new OssIndexServerConfig();
-
+      config = new OssIndexServerConfig();
       config.getConfigFromFile();
-
-      return new OssIndexRequestService(config.getUsername(), config.getToken());
     } catch (e) {
-      return new OssIndexRequestService();
+      // Ignore config load failure
     }
+    return new OssIndexRequestService(
+      args?.user || config?.getUsername(),
+      args?.password || config?.getToken(),
+      args?.cache || config?.getCacheLocation(),
+    );
   }
 
   private getIqRequestService(args: any): IqRequestService {

--- a/src/Audit/AuditIQServer.spec.ts
+++ b/src/Audit/AuditIQServer.spec.ts
@@ -17,19 +17,16 @@
 import expect from '../Tests/TestHelper';
 import { AuditIQServer } from './AuditIQServer';
 import { ReportStatus } from '../Types/ReportStatus';
-
-const oldLog = console.log;
-const oldError = console.error;
+import sinon from 'sinon';
 
 describe('AuditIQServer', () => {
   before(() => {
-    console.log = () => ({});
-    console.error = () => ({});
+    sinon.stub(console, 'log');
+    sinon.stub(console, 'error');
   });
 
   after(() => {
-    console.log = oldLog;
-    console.error = oldError;
+    sinon.restore();
   });
 
   it('should provide a true value if IQ Server Results have policy violations', () => {

--- a/src/Config/IqServerConfig.spec.ts
+++ b/src/Config/IqServerConfig.spec.ts
@@ -40,6 +40,5 @@ describe('IqServerConfig', async () => {
     expect(conf.getUsername()).to.equal('username');
     expect(conf.getToken()).to.equal('password');
     expect(conf.getHost()).to.equal('http://localhost:8070');
-
   });
 });

--- a/src/Config/IqServerConfig.spec.ts
+++ b/src/Config/IqServerConfig.spec.ts
@@ -22,6 +22,11 @@ import os from 'os';
 import { ConfigPersist } from './ConfigPersist';
 
 describe('IqServerConfig', async () => {
+  afterEach(() => {
+    sinon.restore();
+    mock.restore();
+  });
+
   it('should return true when it is able to save a config file', async () => {
     sinon.stub(os, 'homedir').returns('/nonsense');
     mock({ '/nonsense': {} });
@@ -35,7 +40,6 @@ describe('IqServerConfig', async () => {
     expect(conf.getUsername()).to.equal('username');
     expect(conf.getToken()).to.equal('password');
     expect(conf.getHost()).to.equal('http://localhost:8070');
-    mock.restore();
-    sinon.restore();
+
   });
 });

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -53,8 +53,8 @@ export class OssIndexServerConfig extends Config {
 
   public getConfigFromFile(saveLocation: string = this.getConfigLocation()): OssIndexServerConfig {
     const doc = safeLoad(readFileSync(saveLocation, 'utf8'));
-    super.username = doc.Username;
-    super.token = doc.Token;
+    this.username = doc.Username;
+    this.token = doc.Token;
     this.cacheLocation = doc.CacheLocation;
     return this;
   }

--- a/src/Services/OssIndexRequestService.spec.ts
+++ b/src/Services/OssIndexRequestService.spec.ts
@@ -31,7 +31,7 @@ describe('OssIndexRequestService', () => {
     nock(OSS_INDEX_BASE_URL)
       .post('/api/v3/component-report')
       .replyWithError('you messed up!');
-    const requestService = new OssIndexRequestService(undefined, undefined, OSS_INDEX_BASE_URL, CACHE_LOCATION);
+    const requestService = new OssIndexRequestService(undefined, undefined, CACHE_LOCATION, OSS_INDEX_BASE_URL);
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
     return expect(requestService.callOSSIndexOrGetFromCache(coords)).to.eventually.be.rejected;
   });
@@ -48,7 +48,7 @@ describe('OssIndexRequestService', () => {
     nock(OSS_INDEX_BASE_URL)
       .post('/api/v3/component-report')
       .reply(200, expectedOutput);
-    const requestService = new OssIndexRequestService(undefined, undefined, OSS_INDEX_BASE_URL, CACHE_LOCATION);
+    const requestService = new OssIndexRequestService(undefined, undefined, CACHE_LOCATION, OSS_INDEX_BASE_URL);
     const coords = [new Coordinates('commander', '2.12.2', '@types')];
     return expect(requestService.callOSSIndexOrGetFromCache(coords)).to.eventually.deep.equal(expectedOutput);
   });

--- a/src/Services/OssIndexRequestService.ts
+++ b/src/Services/OssIndexRequestService.ts
@@ -38,8 +38,8 @@ export class OssIndexRequestService {
   constructor(
     readonly user?: string,
     readonly password?: string,
+    readonly cacheLocation: string = PATH,
     private baseURL: string = OSS_INDEX_BASE_URL,
-    private cacheLocation: string = PATH,
   ) {}
 
   private checkStatus(res: Response): Response {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,12 @@ let argv = yargs
         description: 'Specify OSS Index password or token',
         demandOption: false,
       },
+      cache: {
+        alias: 'c',
+        type: 'string',
+        description: 'Specify path to use as a cache location',
+        demandOption: false,
+      },
       quiet: {
         alias: 'q',
         type: 'boolean',


### PR DESCRIPTION
Fix bug where cache-location set in .oss-index-config is not being honoured, additionally allowing this location to be set on the CLI.

This pull request makes the following changes:
* Bug-fix #230 - Cache-location configuration ignored
* Feature - Allow cache-location to be set via the CLI
* Feature - Mix configuration and CLI options for OSSI, with CLI taking precedence

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
