### PR TITLE
make exit code non-zero for args in wrong order

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -97,7 +97,7 @@ export class Application {
       await this.populateCoordinatesForIQ();
       console.log(this.sbom);
     } else {
-      shutDownLoggerAndExit(0);
+      shutDownLoggerAndExit(1);
     }
   }
 


### PR DESCRIPTION
While configuring CI on a different project, I noticed auditjs will return a 0 (zero) status code when arguments are passed in the wrong order. This could make CI think all is well, when in fact nothing was well. For example:

Putting the `-q` in the wrong location results in a zero status code. Notice the last line below:

```shell
$ npx auditjs@latest -q ossi && echo $?
npx: installed 101 in 3.873s
auditjs [command]

Commands:
  auditjs iq [options]    Audit this application using Nexus IQ Server
  auditjs config          Set config for OSS Index or Nexus IQ Server
  auditjs ossi [options]  Audit this application using Sonatype OSS Index

Options:
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]
0
```

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
