### PR TITLE
fix: CVE-2021-32796, will change when xmldom@0.7.0 is published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ssri": "^8.0.1",
     "uuid": "^3.3.2",
     "xmlbuilder": "^13.0.2",
-    "xmldom": "^0.5.0",
+    "xmldom": "github:xmldom/xmldom#0.7.0",
     "yargs": "^16.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,10 +2800,9 @@ xmlbuilder@^13.0.2:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-13.0.2.tgz#02ae33614b6a047d1c32b5389c1fdacb2bce47a7"
   integrity sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==
 
-xmldom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
+"xmldom@github:xmldom/xmldom#0.7.0":
+  version "0.7.0"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 y18n@^4.0.0, y18n@^5.0.5, y18n@^5.0.8:
   version "5.0.8"


### PR DESCRIPTION
Due to some issues publishing a new version (0.7.0) of `xmldom` to npmjs.com, I'm following [this recommendation](https://github.com/xmldom/xmldom/discussions/270#discussioncomment-1080132) and pulling in the updated version from GitHub.

This issue #243 is created to track the need to later remove this github version and replace it with a standard version string (like: `'^0.7.0'`) when `xmldom 0.7.0` is published to npmjs.com.

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
