### PR TITLE
Make caching class return undefined if property does not exist

### DIFF
--- a/src/Config/OssIndexServerConfig.spec.ts
+++ b/src/Config/OssIndexServerConfig.spec.ts
@@ -38,4 +38,18 @@ describe('OssIndexServerConfig', async () => {
     mock.restore();
     sinon.restore();
   });
+
+  it('should return undefined when property does not exist', async () => {
+    sinon.stub(os, 'homedir').returns('/nonsense');
+    mock({ '/nonsense': {} });
+
+    const conf = new OssIndexServerConfig();
+
+    expect(conf.getUsername()).to.equal(undefined);
+    expect(conf.getToken()).to.equal(undefined);
+    expect(conf.getCacheLocation()).to.equal(undefined);
+
+    mock.restore();
+    sinon.restore();
+  });
 });

--- a/src/Config/OssIndexServerConfig.ts
+++ b/src/Config/OssIndexServerConfig.ts
@@ -27,16 +27,25 @@ export class OssIndexServerConfig extends Config {
     }
   }
 
-  public getUsername(): string {
-    return this.username;
+  public getUsername(): string | undefined {
+    if (this.username != '') {
+      return this.username;
+    }
+    return undefined;
   }
 
-  public getToken(): string {
-    return this.token;
+  public getToken(): string | undefined {
+    if (this.token != '') {
+      return this.token;
+    }
+    return undefined;
   }
 
-  public getCacheLocation(): string {
-    return this.cacheLocation;
+  public getCacheLocation(): string | undefined {
+    if (this.cacheLocation != '') {
+      return this.cacheLocation;
+    }
+    return undefined;
   }
 
   public async clearCache(): Promise<boolean> {
@@ -53,9 +62,13 @@ export class OssIndexServerConfig extends Config {
 
   public getConfigFromFile(saveLocation: string = this.getConfigLocation()): OssIndexServerConfig {
     const doc = safeLoad(readFileSync(saveLocation, 'utf8')) as OssIndexServerConfigOnDisk;
-    if (doc && doc.Username && doc.Token && doc.CacheLocation) {
+    if (doc && doc.Username) {
       this.username = doc.Username;
+    }
+    if (doc && doc.Token) {
       this.token = doc.Token;
+    }
+    if (doc && doc.CacheLocation) {
       this.cacheLocation = doc.CacheLocation;
     }
 


### PR DESCRIPTION
I am unsure how this broke, but what this PR does is: return `undefined` if a property is set to `''` in `Config`. It's likely we should rethink this class a bit and set those properties as optional, or something akin.

This pull request makes the following changes:
* Updates `src/Config/OssIndexServerConfig.ts` to return `undefined` for properties if they are not set
* Also updates `src/Config/OssIndexServerConfig.ts` to do a better check when setting properties

It relates to the following issue #s:
* Fixes #246 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
