### PR TITLE
security(npm): lock colors library to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "@xmldom/xmldom": "^0.7.2",
     "chalk": "^3.0.0",
-    "colors": "^1.3.1",
+    "colors": "1.4.0",
     "figlet": "^1.2.4",
     "https-proxy-agent": "^5.0.0",
     "js-yaml": "3.13.1",


### PR DESCRIPTION
The maintainer has intentionally published a DoS in 1.4.1 and higher. It is recommended to lock to 1.4.0 and move to another package.

This pull request makes the following changes:
* locks colors.js to `1.4.0`

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:
* Fixes #250

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
