### PR TITLE
added whitelist reviewDate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,13 +266,17 @@ The file should look like:
 
 ```json
 {
-  "ignore": [{ "id": "78a61524-80c5-4371-b6d1-6b32af349043", "reason": "Insert reason here" }]
+  "ignore": [{ "id": "78a61524-80c5-4371-b6d1-6b32af349043", "reason": "Insert reason here", "reviewDate": "2022-07-13T00:00:00.000Z" }]
 }
 ```
 
-The only field that actually matters is `id` and that is the ID you receive from OSS Index for a vulnerability. You can add fields such as `reason` so that you later can understand why you whitelisted a vulnerability.
+The only required field is `id` and that is the ID you receive from OSS Index for a vulnerability.
 
-Any `id` that is whitelisted will be squelched from the results, and not cause a failure.
+The `reason` field can be added so that you later can understand why you whitelisted a vulnerability.
+
+The `reviewDate` field can be used to limit the time a whitelist entry is applicable. Once this date passes, the whitelisted vulnerability will cause an audit failure. This can be useful when adding a temporary whitelist entry while package maintainers fix issues. The audit will fail eventually and serve as a reminder to check if the vulnerability has been solved by package maintainers.
+
+Any `id` that is whitelisted will be squelched from the results, and not cause a failure (unless the reviewDate has passed).
 
 ## Alternative output formats
 

--- a/src/Whitelist/VulnerabilityExcluder.spec.ts
+++ b/src/Whitelist/VulnerabilityExcluder.spec.ts
@@ -26,6 +26,19 @@ const jsonWithOnlyOneMatch = `{
   ]
 }`;
 
+const jsonWithReviewDate = `{
+  "ignore": [ 
+    {
+      "id": "test_id",
+      "reviewDate": "2000-01-01T00:00:00.000Z"
+    },
+    {
+      "id": "test_id2",
+      "reviewDate": "2099-01-01T00:00:00.000Z"
+    }
+  ]
+}`;
+
 const json = `{
   "ignore": [ 
     {
@@ -80,6 +93,17 @@ describe('VulnerabilityExcluder', () => {
     });
     const results = await filterVulnerabilities(ossIndexServerResults, '/nonsensical/auditjs.json');
     expect(results[1].vulnerabilities?.length).to.equal(2);
+    mock.restore();
+  });
+
+  it('should not filter vulnerabilities given an id that matches but the reviewDate has passed', async () => {
+    mock({
+      '/nonsensical': {
+        'auditjs.json': jsonWithReviewDate,
+      },
+    });
+    const results = await filterVulnerabilities(ossIndexServerResults, '/nonsensical/auditjs.json');
+    expect(results[1].vulnerabilities?.length).to.equal(1);
     mock.restore();
   });
 

--- a/src/Whitelist/VulnerabilityExcluder.ts
+++ b/src/Whitelist/VulnerabilityExcluder.ts
@@ -21,6 +21,12 @@ import { OssIndexServerResult } from '../Types/OssIndexServerResult';
 
 const whitelistFilePathPwd = path.join(process.cwd(), 'auditjs.json');
 
+interface WhitelistEntry {
+  id: string
+  reason: string | undefined
+  reviewDate: string | undefined
+}
+
 export const filterVulnerabilities = async (
   results: Array<OssIndexServerResult>,
   whitelistFilePath: string = whitelistFilePathPwd,
@@ -35,11 +41,22 @@ export const filterVulnerabilities = async (
   try {
     const whitelist = JSON.parse(json.toString());
 
-    const whiteListSet = new Set(whitelist.ignore.map((exclusion: any) => exclusion.id));
+    const whiteListMap = new Map<string, WhitelistEntry>(whitelist.ignore.map((exclusion: any) => [exclusion.id, exclusion]));
 
     const newResults = results.map((result) => {
       if (result.vulnerabilities && result.vulnerabilities.length) {
-        const vulns = result.vulnerabilities.filter((vuln) => !whiteListSet.has(vuln.id));
+        const vulns = result.vulnerabilities.filter((vuln) => {
+          if (whiteListMap.has(vuln.id)) {
+            const whitelistEntry = whiteListMap.get(vuln.id)
+            if (whitelistEntry!.reviewDate) {
+              return new Date(whitelistEntry!.reviewDate) < new Date()
+            } else {
+              return false
+            }
+          } else {
+              return true
+          }
+        });
 
         return new OssIndexServerResult({
           ...result,

--- a/src/Whitelist/VulnerabilityExcluder.ts
+++ b/src/Whitelist/VulnerabilityExcluder.ts
@@ -22,9 +22,9 @@ import { OssIndexServerResult } from '../Types/OssIndexServerResult';
 const whitelistFilePathPwd = path.join(process.cwd(), 'auditjs.json');
 
 interface WhitelistEntry {
-  id: string
-  reason: string | undefined
-  reviewDate: string | undefined
+  id: string;
+  reason: string | undefined;
+  reviewDate: string | undefined;
 }
 
 export const filterVulnerabilities = async (
@@ -41,20 +41,22 @@ export const filterVulnerabilities = async (
   try {
     const whitelist = JSON.parse(json.toString());
 
-    const whiteListMap = new Map<string, WhitelistEntry>(whitelist.ignore.map((exclusion: any) => [exclusion.id, exclusion]));
+    const whiteListMap = new Map<string, WhitelistEntry>(
+      whitelist.ignore.map((exclusion: any) => [exclusion.id, exclusion]),
+    );
 
     const newResults = results.map((result) => {
       if (result.vulnerabilities && result.vulnerabilities.length) {
         const vulns = result.vulnerabilities.filter((vuln) => {
           if (whiteListMap.has(vuln.id)) {
-            const whitelistEntry = whiteListMap.get(vuln.id)
+            const whitelistEntry = whiteListMap.get(vuln.id);
             if (whitelistEntry!.reviewDate) {
-              return new Date(whitelistEntry!.reviewDate) < new Date()
+              return new Date(whitelistEntry!.reviewDate) < new Date();
             } else {
-              return false
+              return false;
             }
           } else {
-              return true
+            return true;
           }
         });
 


### PR DESCRIPTION
We occasionally add whitelist entries for vulnerabilities which don't have a current solution, but are likely to be resolved by package maintainers at some point in the future. The risk in adding a whitelist entry is we will undoubtedly forget to come back and fix the issue / upgrade packages once the vulnerability has been resolved.

This PR adds a whitelist `reviewDate` field, which will cause the audit to fail after the date passes. This is useful to ensure temporary whitelist entried don't get "forgotten" by causing the audit to fail.

This pull request makes the following changes:
* Updates VulnerabilitiyExcluder to handle optional `reviewDate` field in auditjs.json whitelist file
* Add unit tests
* Update README.md documention for whitelist usage

It relates to the following issue #s:
* Fixes #258 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
