### PR TITLE
Filter results of OSSI scan by score, fixes #261

### DIFF
--- a/src/Application/Application.ts
+++ b/src/Application/Application.ts
@@ -166,6 +166,8 @@ export class Application {
       this.spinner.maybeCreateMessageForSpinner('Reticulating splines');
       logMessage('Turning response into Array<OssIndexServerResult>', DEBUG);
       let ossIndexResults: Array<OssIndexServerResult> = res.map((y: any) => {
+        logMessage(`Filtering results by score threshold: ${args.score}`, DEBUG);
+        y.vulnerabilities = y.vulnerabilities.filter((vuln: any) => vuln.cvssScore > args.score);
         return new OssIndexServerResult(y);
       });
       logMessage('Response morphed into Array<OssIndexServerResult>', DEBUG, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,13 @@ let argv = yargs
         type: 'boolean',
         demandOption: false,
       },
+      score: {
+        alias: 's',
+        type: 'number',
+        description: 'Ignore entries with score less than this number',
+        demandOption: false,
+        default: 0,
+      },
     })
       .command('sbom', 'Output the purl only CycloneDx sbom to std_out');
   }).argv;


### PR DESCRIPTION
Allows the setting of a minimum vulnerability score threshold, to filter out relatively minor reports.

This pull request makes the following changes:
- add an arg to `ossi` to specify a minimum score threshold, defaults to `0` to match current behavior

It relates to the following issue #s:
* Fixes #261 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck



Note: I looked for a place to add tests but didn't see a good spot to do so.

```
[ timkpaine@mbp-m1 ]: node bin/index.js ossi -q -s 3.6
[1/1] - pkg:npm/node-fetch@2.6.7 - 1 vulnerability found!

  Vulnerability Title:  1 vulnerability found
  ID:  sonatype-2022-3677
  Description:  1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account
  CVSS Score:  3.7
  CVSS Vector:  CVSS:3.1/AV:A/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N
  Reference:  https://ossindex.sonatype.org/vulnerability/sonatype-2022-3677

[ timkpaine@mbp-m1 ]: node bin/index.js ossi -q -s 3.8


[ timkpaine@mbp-m1 ]:

```
