### PR TITLE
fix error: error TS2688: Cannot find type definition file for 'node'.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,6 @@
     "sourceMap": true,
     "declaration": true,
     "resolveJsonModule": true,
-    "typeRoots": [
-      "./node_modules/@types",
-    ],
   },
   "include": [
     "src/**/*.d.ts",


### PR DESCRIPTION
fix error: error TS2688: Cannot find type definition file for 'node'.

The error appears to have been intermittent, but there was also some posts stating the typeRoots compiler option was no longer needed. It didn't appear to cause harm, and "less is more"...

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck
