### PR TITLE
fix: CVE-2025-64718 in js-yaml : 3.14.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 * Make sure to fill out an issue for your PR, so that we have traceability as to what you are trying to fix,
 versus how you fixed it.
 * Spaces (not tabs), and 2 of them, that's what we like. Set your code style :)
-* Sign the [Sonatype CLA](https://sonatypecla.herokuapp.com/sign-cla)
+* Sign the [Sonatype CLA](https://the-cla.eu1.sonatype-se.com/)
 * Try to fix one thing per pull request! Many people work on this code, so the more focused your changes are, the less
 of a headache other people will have when they merge their work in.
 * Ensure your Pull Request passes tests either locally or via CircleCI (it will run automatically on your PR)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,5 +12,6 @@ External contributors:
 - [@francois-roget](https://github.com/francois-roget) (François Roget) for [Ingenico Group](https://github.com/ingenico-group)
 - [@tomhooijenga](https://github.com/tomhooijenga) (Tom Hooijenga)
 - [@lostunicorn](https://github.com/lostunicorn) (Jeroen De Wachter)
+- [@d-ellis](https://github.com/d-ellis) (Daniel Ellis)
 
 Possibly You!

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "colors": "1.4.0",
     "figlet": "^1.2.4",
     "https-proxy-agent": "^5.0.0",
-    "js-yaml": "3.13.1",
+    "js-yaml": "3.14.2",
     "log4js": "^6.4.0",
     "node-fetch": "^2.6.8",
     "node-persist": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,10 +1815,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+js-yaml@3.14.2:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Bumped `js-yaml` version to 3.14.2 to patch CVE-2025-64718

Also fixed the link for the Sonatype CLA in `CONTRIBUTING.md`

It relates to the following issue #s:
* Fixes #282 

cc @bhamail / @DarthHater / @allenhsieh / @ken-duck