### PR TITLE
fix(security): remove hardcoded default credentials and add file permissions

### DIFF
--- a/src/Config/AppConfig.ts
+++ b/src/Config/AppConfig.ts
@@ -41,19 +41,17 @@ export class AppConfig {
     );
 
     if (type == 'iq') {
-      username = 'admin';
-      token = 'admin123';
+      // SECURITY: Removed hardcoded default credentials (CWE-798)
+      // Users must now provide their own credentials
+      let host = '';
 
-      let host = 'http://localhost:8070';
+      username = await this.setRequiredVariable('What is your username? ');
 
-      username = await this.setVariable(`What is your username (default: ${username})? `, username);
-
-      token = await this.setVariable(
-        `What is your password/token (pretty please do not save your password to the filesystem, USE A TOKEN) (default: ${token})? `,
-        token,
+      token = await this.setRequiredVariable(
+        'What is your password/token (please use a token, not your password)? ',
       );
 
-      host = await this.setVariable(`What is your IQ Server address (default: ${host})? `, host);
+      host = await this.setRequiredVariable('What is your IQ Server address (e.g., https://iq.example.com:8070)? ');
 
       this.rl.close();
 
@@ -97,6 +95,23 @@ export class AppConfig {
       this.rl.question(message, (answer) => {
         resolve(answer || defaultValue);
       });
+    });
+  }
+
+  // SECURITY: Require user to provide a value - no defaults allowed
+  private setRequiredVariable(message: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const askQuestion = (): void => {
+        this.rl.question(message, (answer) => {
+          if (answer && answer.trim() !== '') {
+            resolve(answer.trim());
+          } else {
+            console.log('This field is required. Please provide a value.');
+            askQuestion();
+          }
+        });
+      };
+      askQuestion();
     });
   }
 }

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -16,8 +16,7 @@
 
 import path from 'path';
 import { homedir } from 'os';
-import { mkdirSync, existsSync } from 'fs';
-import { writeFileSync } from 'fs';
+import { mkdirSync, existsSync, writeFileSync, chmodSync } from 'fs';
 import { safeDump } from 'js-yaml';
 
 import { ConfigPersist } from './ConfigPersist';
@@ -40,14 +39,19 @@ export abstract class Config {
   }
 
   private tryCreateDirectory(): void {
-    if (!existsSync(path.join(homedir(), this.directoryName))) {
-      mkdirSync(path.join(homedir(), this.directoryName));
+    const dirPath = path.join(homedir(), this.directoryName);
+    if (!existsSync(dirPath)) {
+      // SECURITY: Create directory with restrictive permissions (CWE-732)
+      mkdirSync(dirPath, { mode: 0o700 });
     }
     return;
   }
 
   public saveFile(objectToSave: ConfigPersist): boolean {
-    writeFileSync(this.getConfigLocation(), safeDump(objectToSave, { skipInvalid: true }));
+    const configPath = this.getConfigLocation();
+    writeFileSync(configPath, safeDump(objectToSave, { skipInvalid: true }));
+    // SECURITY: Set restrictive file permissions - owner read/write only (CWE-732)
+    chmodSync(configPath, 0o600);
     this.getConfigFromFile();
     return true;
   }


### PR DESCRIPTION
## Summary

Security fixes addressing critical vulnerabilities identified during security research:

### Critical: Hardcoded Default Credentials (CWE-798)
- **Files**: `src/Config/AppConfig.ts`
- **Issue**: IQ Server config defaulted to `admin/admin123` credentials
- **Fix**: Removed all hardcoded defaults, added `setRequiredVariable()` method that prompts until user provides a value

### High: Insecure File Permissions (CWE-732)
- **Files**: `src/Config/Config.ts`
- **Issue**: Config files and directories created with default permissions
- **Fix**: Directory created with `0o700`, config files with `0o600` (owner read/write only)

## Breaking Changes

IQ Server credentials are now **required** and must be explicitly provided. No defaults are allowed.

## Test Plan

- [x] TypeScript compilation passes
- [x] Code review passed
- [ ] Manual testing of interactive config flow

## Related Issues

Fixes security vulnerabilities reported in #287

---

🤖 Generated with [Claude Code](https://claude.ai/code)