### PR TITLE
fix: Use `Bearer` auth with Sonatype Guide PAT tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ results for 24 hours to avoid unnecessary credit consumption.
 Get a free API token at <https://guide.sonatype.com> under **Settings > API Tokens**.
 Pass the token via `--token` or store it with `auditjs config`.
 
+Sonatype Guide issues two kinds of tokens:
+
+- **Personal Access Tokens (PAT)** — format `sonatype_pat_*`. Use `--token` alone (no `--user`). AuditJS sends these as `Authorization: Bearer <token>`.
+- **OSS Index compatibility tokens** — used with `--user` (your email) and `--token`. AuditJS sends these as `Authorization: Basic <base64(user:token)>`.
+
 You can specify your credentials on either the command line or the configuration
 file. It is almost certainly better to put the credentials in a configuration
 file as described above, as using them on the command line is less secure.

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019-Present Sonatype Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, vi, describe, it, afterEach, beforeEach } from 'vitest';
+import { GuideRequestService } from './GuideRequestService';
+import { OSSIndexCompatibilityApi } from '@sonatype/sonatype-guide-api-client';
+import { Coordinates } from '../Types/Coordinates';
+import { rmSync, existsSync } from 'fs';
+
+const CACHE_PATH = '/tmp/.sonatype-guide-test';
+const SERVER = 'https://api.guide.sonatype.com';
+
+describe('GuideRequestService', () => {
+  beforeEach(() => {
+    if (existsSync(CACHE_PATH)) rmSync(CACHE_PATH, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends Authorization: Bearer when accessToken is set (PAT token mode)', async () => {
+    const spy = vi
+      .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+
+    const svc = new GuideRequestService(undefined, undefined, CACHE_PATH, SERVER, 'sonatype_pat_test123');
+    const coords = [new Coordinates('test', '1.0.0', '')];
+    await svc.callGuideOrGetFromCache(coords, 'npm');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const initOverrides = spy.mock.calls[0][1] as Function;
+    expect(initOverrides).toBeDefined();
+
+    const result = await initOverrides({ init: { method: 'POST', headers: { 'Content-Type': 'application/json' } } });
+    expect(result.headers).toMatchObject({ Authorization: 'Bearer sonatype_pat_test123' });
+    expect(result.headers['Content-Type']).toEqual('application/json');
+  });
+
+  it('does not override Authorization when no accessToken (Basic auth mode)', async () => {
+    const spy = vi
+      .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+
+    const svc = new GuideRequestService('myuser', 'mytoken', CACHE_PATH, SERVER, undefined);
+    const coords = [new Coordinates('test', '1.0.0', '')];
+    await svc.callGuideOrGetFromCache(coords, 'npm');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const initOverrides = spy.mock.calls[0][1];
+    expect(initOverrides).toBeUndefined();
+  });
+});

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -19,7 +19,7 @@ import { GuideRequestService } from './GuideRequestService';
 import { OSSIndexCompatibilityApi } from '@sonatype/sonatype-guide-api-client';
 import type { InitOverrideFunction } from '@sonatype/sonatype-guide-api-client';
 import { Coordinates } from '../Types/Coordinates';
-import { rmSync, existsSync } from 'fs';
+import { rmSync, existsSync } from 'node:fs';
 
 const CACHE_PATH = '/tmp/.sonatype-guide-test';
 const SERVER = 'https://api.guide.sonatype.com';

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -17,6 +17,7 @@
 import { expect, vi, describe, it, afterEach, beforeEach } from 'vitest';
 import { GuideRequestService } from './GuideRequestService';
 import { OSSIndexCompatibilityApi } from '@sonatype/sonatype-guide-api-client';
+import type { InitOverrideFunction } from '@sonatype/sonatype-guide-api-client';
 import { Coordinates } from '../Types/Coordinates';
 import { rmSync, existsSync } from 'fs';
 
@@ -35,14 +36,16 @@ describe('GuideRequestService', () => {
   it('sends Authorization: Bearer when accessToken is set (PAT token mode)', async () => {
     const spy = vi
       .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
-      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] }] as Awaited<
+        ReturnType<typeof OSSIndexCompatibilityApi.prototype.getComponentReports>
+      >);
 
     const svc = new GuideRequestService(undefined, undefined, CACHE_PATH, SERVER, 'sonatype_pat_test123');
     const coords = [new Coordinates('test', '1.0.0', '')];
     await svc.callGuideOrGetFromCache(coords, 'npm');
 
     expect(spy).toHaveBeenCalledOnce();
-    const initOverrides = spy.mock.calls[0][1] as Function;
+    const initOverrides = spy.mock.calls[0][1] as InitOverrideFunction;
     expect(initOverrides).toBeDefined();
 
     const result = await initOverrides({ init: { method: 'POST', headers: { 'Content-Type': 'application/json' } } });
@@ -53,7 +56,9 @@ describe('GuideRequestService', () => {
   it('does not override Authorization when no accessToken (Basic auth mode)', async () => {
     const spy = vi
       .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
-      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] }] as Awaited<
+        ReturnType<typeof OSSIndexCompatibilityApi.prototype.getComponentReports>
+      >);
 
     const svc = new GuideRequestService('myuser', 'mytoken', CACHE_PATH, SERVER, undefined);
     const coords = [new Coordinates('test', '1.0.0', '')];

--- a/src/Services/GuideRequestService.ts
+++ b/src/Services/GuideRequestService.ts
@@ -15,7 +15,7 @@
  */
 
 import { OSSIndexCompatibilityApi, RecommendationsApi, Configuration } from '@sonatype/sonatype-guide-api-client';
-import type { RecommendationResponse } from '@sonatype/sonatype-guide-api-client';
+import type { RecommendationResponse, InitOverrideFunction } from '@sonatype/sonatype-guide-api-client';
 import NodePersist from 'node-persist';
 import path from 'path';
 import { homedir } from 'os';
@@ -121,7 +121,11 @@ export class GuideRequestService {
 
   private async getResultsFromGuide(purls: string[]): Promise<OssIndexServerResultJSON[]> {
     try {
-      const response = await this.api.getComponentReports({ purlRequestPost: { coordinates: purls } });
+      // PAT tokens require Bearer auth; the OSSIndexCompatibilityApi SDK only supports Basic by default.
+      const initOverrides: InitOverrideFunction | undefined = this.accessToken
+        ? async ({ init }) => ({ ...init, headers: { ...init.headers, Authorization: `Bearer ${this.accessToken}` } })
+        : undefined;
+      const response = await this.api.getComponentReports({ purlRequestPost: { coordinates: purls } }, initOverrides);
       return response as unknown as OssIndexServerResultJSON[];
     } catch (err) {
       const status =


### PR DESCRIPTION
Resolves #293 

cc @sonatype-nexus-community/auditjs
