### PR TITLE
fix: `--bower` audit sends raw GitHub-ref versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ results for 24 hours to avoid unnecessary credit consumption.
 Get a free API token at <https://guide.sonatype.com> under **Settings > API Tokens**.
 Pass the token via `--token` or store it with `auditjs config`.
 
+Sonatype Guide issues two kinds of tokens:
+
+- **Personal Access Tokens (PAT)** — format `sonatype_pat_*`. Use `--token` alone (no `--user`). AuditJS sends these as `Authorization: Bearer <token>`.
+- **OSS Index compatibility tokens** — used with `--user` (your email) and `--token`. AuditJS sends these as `Authorization: Basic <base64(user:token)>`.
+
 You can specify your credentials on either the command line or the configuration
 file. It is almost certainly better to put the credentials in a configuration
 file as described above, as using them on the command line is less secure.

--- a/src/Munchers/Bower.spec.ts
+++ b/src/Munchers/Bower.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019-Present Sonatype Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import mockFs from 'mock-fs';
+import { Bower } from './Bower';
+
+describe('Bower', () => {
+  afterEach(() => {
+    mockFs.restore();
+    vi.restoreAllMocks();
+  });
+
+  describe('getInstalledDeps()', () => {
+    // ------------------------------------------------------------------
+    // Bug-confirmation tests: these PASS with the current (unfixed) code.
+    // They document the defective behaviour that causes HTTP 400 from the
+    // Sonatype Guide / OSS Index API when Bower deps use GitHub refs.
+    // ------------------------------------------------------------------
+
+    it('[BUG] returns raw GitHub ref as version, only stripping the leading ~', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
+      mockFs({
+        '/fake/bower.json': JSON.stringify({
+          dependencies: {
+            'iron-elements': 'PolymerElements/iron-elements#~1.0.4',
+            catiline: 'calvinmetcalf/catiline#2.9.3',
+          },
+        }),
+      });
+
+      const deps = await new Bower().getInstalledDeps();
+
+      // Only the first ~ is stripped; the rest of the GitHub ref remains.
+      // This produces invalid PURLs that cause the API to reject the entire batch.
+      const ironElements = deps.find((d) => d.name === 'iron-elements');
+      expect(ironElements?.version).toBe('PolymerElements/iron-elements#1.0.4');
+
+      const catiline = deps.find((d) => d.name === 'catiline');
+      expect(catiline?.version).toBe('calvinmetcalf/catiline#2.9.3');
+    });
+
+    it('[BUG] passes caret-range specifier verbatim as version (^ is not stripped)', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
+      mockFs({
+        '/fake/bower.json': JSON.stringify({
+          dependencies: { lodash: '^4.17.11' },
+        }),
+      });
+
+      const deps = await new Bower().getInstalledDeps();
+
+      // ^ prefix is not handled at all — results in an invalid semver PURL
+      expect(deps[0].version).toBe('^4.17.11');
+    });
+
+    // ------------------------------------------------------------------
+    // Fix-behavior tests: these FAIL with the current code and should
+    // PASS once Bower.getInstalledDeps() reads resolved versions from
+    // bower_components/<name>/.bower.json instead of bower.json specifiers.
+    // ------------------------------------------------------------------
+
+    it('resolves GitHub ref to exact semver from bower_components/.bower.json', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
+      mockFs({
+        '/fake/bower.json': JSON.stringify({
+          dependencies: { 'iron-elements': 'PolymerElements/iron-elements#~1.0.4' },
+        }),
+        '/fake/bower_components/iron-elements/.bower.json': JSON.stringify({
+          version: '1.0.4',
+        }),
+      });
+
+      const deps = await new Bower().getInstalledDeps();
+
+      expect(deps).toHaveLength(1);
+      expect(deps[0].name).toBe('iron-elements');
+      expect(deps[0].version).toBe('1.0.4');
+    });
+
+    it('skips package gracefully when bower_components entry is absent', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
+      mockFs({
+        '/fake/bower.json': JSON.stringify({
+          dependencies: { 'private-pkg': 'git+https://github.com/acme/private.git' },
+        }),
+        // No bower_components directory — simulates a dep that was never installed locally
+      });
+
+      const deps = await new Bower().getInstalledDeps();
+
+      // Should be silently skipped rather than forwarded as an invalid PURL that
+      // causes HTTP 400 and drops every other package in the same API batch.
+      expect(deps).toHaveLength(0);
+    });
+
+    it('resolves tilde semver range to exact installed version from .bower.json', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
+      mockFs({
+        '/fake/bower.json': JSON.stringify({
+          dependencies: { polymer: '~1.9.0' },
+        }),
+        '/fake/bower_components/polymer/.bower.json': JSON.stringify({
+          version: '1.9.8',
+        }),
+      });
+
+      const deps = await new Bower().getInstalledDeps();
+
+      expect(deps[0].version).toBe('1.9.8');
+    });
+
+    // ------------------------------------------------------------------
+    // Regression: devDependencies flag must still work after the fix.
+    // ------------------------------------------------------------------
+
+    it('includes devDependencies when the devDependencies flag is true', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
+      mockFs({
+        '/fake/bower.json': JSON.stringify({
+          dependencies: { polymer: '~1.9.0' },
+          devDependencies: { 'web-component-tester': '~6.9.2' },
+        }),
+        '/fake/bower_components/polymer/.bower.json': JSON.stringify({ version: '1.9.8' }),
+        '/fake/bower_components/web-component-tester/.bower.json': JSON.stringify({ version: '6.9.2' }),
+      });
+
+      const deps = await new Bower(true).getInstalledDeps();
+
+      expect(deps).toHaveLength(2);
+      expect(deps.map((d) => d.name)).toContain('web-component-tester');
+    });
+  });
+});

--- a/src/Munchers/Bower.spec.ts
+++ b/src/Munchers/Bower.spec.ts
@@ -25,54 +25,6 @@ describe('Bower', () => {
   });
 
   describe('getInstalledDeps()', () => {
-    // ------------------------------------------------------------------
-    // Bug-confirmation tests: these PASS with the current (unfixed) code.
-    // They document the defective behaviour that causes HTTP 400 from the
-    // Sonatype Guide / OSS Index API when Bower deps use GitHub refs.
-    // ------------------------------------------------------------------
-
-    it('[BUG] returns raw GitHub ref as version, only stripping the leading ~', async () => {
-      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
-      mockFs({
-        '/fake/bower.json': JSON.stringify({
-          dependencies: {
-            'iron-elements': 'PolymerElements/iron-elements#~1.0.4',
-            catiline: 'calvinmetcalf/catiline#2.9.3',
-          },
-        }),
-      });
-
-      const deps = await new Bower().getInstalledDeps();
-
-      // Only the first ~ is stripped; the rest of the GitHub ref remains.
-      // This produces invalid PURLs that cause the API to reject the entire batch.
-      const ironElements = deps.find((d) => d.name === 'iron-elements');
-      expect(ironElements?.version).toBe('PolymerElements/iron-elements#1.0.4');
-
-      const catiline = deps.find((d) => d.name === 'catiline');
-      expect(catiline?.version).toBe('calvinmetcalf/catiline#2.9.3');
-    });
-
-    it('[BUG] passes caret-range specifier verbatim as version (^ is not stripped)', async () => {
-      vi.spyOn(process, 'cwd').mockReturnValue('/fake');
-      mockFs({
-        '/fake/bower.json': JSON.stringify({
-          dependencies: { lodash: '^4.17.11' },
-        }),
-      });
-
-      const deps = await new Bower().getInstalledDeps();
-
-      // ^ prefix is not handled at all — results in an invalid semver PURL
-      expect(deps[0].version).toBe('^4.17.11');
-    });
-
-    // ------------------------------------------------------------------
-    // Fix-behavior tests: these FAIL with the current code and should
-    // PASS once Bower.getInstalledDeps() reads resolved versions from
-    // bower_components/<name>/.bower.json instead of bower.json specifiers.
-    // ------------------------------------------------------------------
-
     it('resolves GitHub ref to exact semver from bower_components/.bower.json', async () => {
       vi.spyOn(process, 'cwd').mockReturnValue('/fake');
       mockFs({

--- a/src/Munchers/Bower.ts
+++ b/src/Munchers/Bower.ts
@@ -40,15 +40,26 @@ export class Bower implements Muncher {
     const file = fs.readFileSync(path.join(process.cwd(), 'bower.json'));
     const json = JSON.parse(file.toString());
 
-    Object.keys(json.dependencies).map((x: string) => {
-      const version: string = json.dependencies[x];
-      depsArray.push(new Coordinates(x, version.replace('~', ''), ''));
+    const resolve = (name: string): string | null => {
+      try {
+        const bowerJson = JSON.parse(
+          fs.readFileSync(path.join(process.cwd(), 'bower_components', name, '.bower.json'), 'utf8'),
+        );
+        return /^\d+\.\d+\.\d+/.test(bowerJson.version) ? bowerJson.version : null;
+      } catch {
+        return null;
+      }
+    };
+
+    Object.keys(json.dependencies).forEach((x: string) => {
+      const version = resolve(x);
+      if (version) depsArray.push(new Coordinates(x, version, ''));
     });
 
     if (this.devDependencies) {
-      Object.keys(json.devDependencies).map((x: string) => {
-        const version: string = json.devDependencies[x];
-        depsArray.push(new Coordinates(x, version.replace('~', ''), ''));
+      Object.keys(json.devDependencies).forEach((x: string) => {
+        const version = resolve(x);
+        if (version) depsArray.push(new Coordinates(x, version, ''));
       });
     }
 

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -134,9 +134,7 @@ describe('GuideRequestService', () => {
     it('skips the API call entirely when every coordinate has a non-semver version', async () => {
       const service = new GuideRequestService('user', 'token', CACHE_LOCATION, GUIDE_BASE_URL);
 
-      const getResultsSpy = vi
-        .spyOn(service as any, 'getResultsFromGuide')
-        .mockResolvedValue([]);
+      const getResultsSpy = vi.spyOn(service as any, 'getResultsFromGuide').mockResolvedValue([]);
 
       const coords = [
         new Coordinates('iron-elements', 'PolymerElements/iron-elements#1.0.4'),

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019-Present Sonatype Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, vi, describe, it, afterEach, beforeEach } from 'vitest';
+import { GuideRequestService } from './GuideRequestService';
+import { OSSIndexCompatibilityApi } from '@sonatype/sonatype-guide-api-client';
+import { Coordinates } from '../Types/Coordinates';
+import { rmSync, existsSync } from 'fs';
+
+const CACHE_PATH = '/tmp/.sonatype-guide-test';
+const SERVER = 'https://api.guide.sonatype.com';
+
+describe('GuideRequestService', () => {
+  beforeEach(() => {
+    if (existsSync(CACHE_PATH)) rmSync(CACHE_PATH, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends Authorization: Bearer when accessToken is set (PAT token mode)', async () => {
+    const spy = vi
+      .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+
+    const svc = new GuideRequestService(undefined, undefined, CACHE_PATH, SERVER, 'sonatype_pat_test123');
+    const coords = [new Coordinates('test', '1.0.0', '')];
+    await svc.callGuideOrGetFromCache(coords, 'npm');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const initOverrides = spy.mock.calls[0][1] as Function;
+    expect(initOverrides).toBeDefined();
+
+    const result = await initOverrides({ init: { method: 'POST', headers: { 'Content-Type': 'application/json' } } });
+    expect(result.headers).toMatchObject({ Authorization: 'Bearer sonatype_pat_test123' });
+    expect(result.headers['Content-Type']).toEqual('application/json');
+  });
+
+  it('does not override Authorization when no accessToken (Basic auth mode)', async () => {
+    const spy = vi
+      .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+
+    const svc = new GuideRequestService('myuser', 'mytoken', CACHE_PATH, SERVER, undefined);
+    const coords = [new Coordinates('test', '1.0.0', '')];
+    await svc.callGuideOrGetFromCache(coords, 'npm');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const initOverrides = spy.mock.calls[0][1];
+    expect(initOverrides).toBeUndefined();
+  });
+});

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -19,7 +19,7 @@ import { GuideRequestService } from './GuideRequestService';
 import { OSSIndexCompatibilityApi } from '@sonatype/sonatype-guide-api-client';
 import type { InitOverrideFunction } from '@sonatype/sonatype-guide-api-client';
 import { Coordinates } from '../Types/Coordinates';
-import { rmSync, existsSync } from 'fs';
+import { rmSync, existsSync } from 'node:fs';
 
 const CACHE_PATH = '/tmp/.sonatype-guide-test';
 const SERVER = 'https://api.guide.sonatype.com';

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -17,6 +17,7 @@
 import { expect, vi, describe, it, afterEach, beforeEach } from 'vitest';
 import { GuideRequestService } from './GuideRequestService';
 import { OSSIndexCompatibilityApi } from '@sonatype/sonatype-guide-api-client';
+import type { InitOverrideFunction } from '@sonatype/sonatype-guide-api-client';
 import { Coordinates } from '../Types/Coordinates';
 import { rmSync, existsSync } from 'fs';
 
@@ -35,14 +36,16 @@ describe('GuideRequestService', () => {
   it('sends Authorization: Bearer when accessToken is set (PAT token mode)', async () => {
     const spy = vi
       .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
-      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] }] as Awaited<
+        ReturnType<typeof OSSIndexCompatibilityApi.prototype.getComponentReports>
+      >);
 
     const svc = new GuideRequestService(undefined, undefined, CACHE_PATH, SERVER, 'sonatype_pat_test123');
     const coords = [new Coordinates('test', '1.0.0', '')];
     await svc.callGuideOrGetFromCache(coords, 'npm');
 
     expect(spy).toHaveBeenCalledOnce();
-    const initOverrides = spy.mock.calls[0][1] as Function;
+    const initOverrides = spy.mock.calls[0][1] as InitOverrideFunction;
     expect(initOverrides).toBeDefined();
 
     const result = await initOverrides({ init: { method: 'POST', headers: { 'Content-Type': 'application/json' } } });
@@ -53,7 +56,9 @@ describe('GuideRequestService', () => {
   it('does not override Authorization when no accessToken (Basic auth mode)', async () => {
     const spy = vi
       .spyOn(OSSIndexCompatibilityApi.prototype, 'getComponentReports')
-      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] } as any]);
+      .mockResolvedValue([{ coordinates: 'pkg:npm/test@1.0.0', reference: '', vulnerabilities: [] }] as Awaited<
+        ReturnType<typeof OSSIndexCompatibilityApi.prototype.getComponentReports>
+      >);
 
     const svc = new GuideRequestService('myuser', 'mytoken', CACHE_PATH, SERVER, undefined);
     const coords = [new Coordinates('test', '1.0.0', '')];

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -81,35 +81,6 @@ describe('GuideRequestService', () => {
   });
 
   describe('callGuideOrGetFromCache() with non-semver bower version strings', () => {
-    // ------------------------------------------------------------------
-    // Bug-confirmation test: PASSES with current (unfixed) code.
-    // Shows that a single non-semver PURL causes the entire batch to fail
-    // with no results returned — including valid packages in the same chunk.
-    // ------------------------------------------------------------------
-
-    it('[BUG] API error for non-semver PURL causes the entire batch to fail', async () => {
-      const service = new GuideRequestService('user', 'token', CACHE_LOCATION, GUIDE_BASE_URL);
-
-      // Simulate the HTTP 400 the Guide API returns when it receives an invalid PURL.
-      vi.spyOn(service as any, 'getResultsFromGuide').mockRejectedValueOnce(
-        new Error('There was an error making the request to Sonatype Guide (HTTP 400)'),
-      );
-
-      const coords = [
-        new Coordinates('iron-elements', 'PolymerElements/iron-elements#1.0.4'),
-        new Coordinates('polymer', '1.9.8'), // valid — but lost along with the bad one
-      ];
-
-      // Both packages disappear: the valid polymer@1.9.8 is never reported.
-      await expect(service.callGuideOrGetFromCache(coords, 'bower')).rejects.toThrow('400');
-    });
-
-    // ------------------------------------------------------------------
-    // Fix-behavior tests: these FAIL with current code and should PASS
-    // once callGuideOrGetFromCache() filters out non-semver PURLs before
-    // forwarding the batch to the API.
-    // ------------------------------------------------------------------
-
     it('filters non-semver PURLs from the batch before sending to the API', async () => {
       const service = new GuideRequestService('user', 'token', CACHE_LOCATION, GUIDE_BASE_URL);
 

--- a/src/Services/GuideRequestService.spec.ts
+++ b/src/Services/GuideRequestService.spec.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019-Present Sonatype Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GuideRequestService } from './GuideRequestService';
+import { Coordinates } from '../Types/Coordinates';
+
+// node-persist is mocked globally so tests never touch the filesystem cache.
+vi.mock('node-persist', () => ({
+  default: {
+    init: vi.fn().mockResolvedValue(undefined),
+    getItem: vi.fn().mockResolvedValue(undefined), // nothing cached
+    setItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const CACHE_LOCATION = '/tmp/.guide-test';
+const GUIDE_BASE_URL = 'http://test.guide.sonatype.com';
+
+describe('GuideRequestService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('callGuideOrGetFromCache() with non-semver bower version strings', () => {
+    // ------------------------------------------------------------------
+    // Bug-confirmation test: PASSES with current (unfixed) code.
+    // Shows that a single non-semver PURL causes the entire batch to fail
+    // with no results returned — including valid packages in the same chunk.
+    // ------------------------------------------------------------------
+
+    it('[BUG] API error for non-semver PURL causes the entire batch to fail', async () => {
+      const service = new GuideRequestService('user', 'token', CACHE_LOCATION, GUIDE_BASE_URL);
+
+      // Simulate the HTTP 400 the Guide API returns when it receives an invalid PURL.
+      vi.spyOn(service as any, 'getResultsFromGuide').mockRejectedValueOnce(
+        new Error('There was an error making the request to Sonatype Guide (HTTP 400)'),
+      );
+
+      const coords = [
+        new Coordinates('iron-elements', 'PolymerElements/iron-elements#1.0.4'),
+        new Coordinates('polymer', '1.9.8'), // valid — but lost along with the bad one
+      ];
+
+      // Both packages disappear: the valid polymer@1.9.8 is never reported.
+      await expect(service.callGuideOrGetFromCache(coords, 'bower')).rejects.toThrow('400');
+    });
+
+    // ------------------------------------------------------------------
+    // Fix-behavior tests: these FAIL with current code and should PASS
+    // once callGuideOrGetFromCache() filters out non-semver PURLs before
+    // forwarding the batch to the API.
+    // ------------------------------------------------------------------
+
+    it('filters non-semver PURLs from the batch before sending to the API', async () => {
+      const service = new GuideRequestService('user', 'token', CACHE_LOCATION, GUIDE_BASE_URL);
+
+      const getResultsSpy = vi
+        .spyOn(service as any, 'getResultsFromGuide')
+        .mockResolvedValueOnce([
+          { coordinates: 'pkg:bower/polymer@1.9.8', reference: '', vulnerabilities: [] },
+        ]);
+
+      const coords = [
+        new Coordinates('iron-elements', 'PolymerElements/iron-elements#1.0.4'),
+        new Coordinates('polymer', '1.9.8'),
+      ];
+
+      await service.callGuideOrGetFromCache(coords, 'bower');
+
+      // The API must receive exactly the one valid PURL.
+      const [sentPurls] = getResultsSpy.mock.calls[0] as [string[]];
+      expect(sentPurls).toHaveLength(1);
+      expect(sentPurls[0]).toBe('pkg:bower/polymer@1.9.8');
+      expect(sentPurls.some((p) => p.includes('PolymerElements'))).toBe(false);
+    });
+
+    it('skips the API call entirely when every coordinate has a non-semver version', async () => {
+      const service = new GuideRequestService('user', 'token', CACHE_LOCATION, GUIDE_BASE_URL);
+
+      const getResultsSpy = vi
+        .spyOn(service as any, 'getResultsFromGuide')
+        .mockResolvedValue([]);
+
+      const coords = [
+        new Coordinates('iron-elements', 'PolymerElements/iron-elements#1.0.4'),
+        new Coordinates('catiline', 'calvinmetcalf/catiline#2.9.3'),
+      ];
+
+      const result = await service.callGuideOrGetFromCache(coords, 'bower');
+
+      // No HTTP request should be made; the result is an empty array rather than an error.
+      expect(getResultsSpy).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/Services/GuideRequestService.ts
+++ b/src/Services/GuideRequestService.ts
@@ -15,7 +15,7 @@
  */
 
 import { OSSIndexCompatibilityApi, RecommendationsApi, Configuration } from '@sonatype/sonatype-guide-api-client';
-import type { RecommendationResponse } from '@sonatype/sonatype-guide-api-client';
+import type { RecommendationResponse, InitOverrideFunction } from '@sonatype/sonatype-guide-api-client';
 import NodePersist from 'node-persist';
 import path from 'path';
 import { homedir } from 'os';
@@ -121,7 +121,11 @@ export class GuideRequestService {
 
   private async getResultsFromGuide(purls: string[]): Promise<OssIndexServerResultJSON[]> {
     try {
-      const response = await this.api.getComponentReports({ purlRequestPost: { coordinates: purls } });
+      // PAT tokens require Bearer auth; the OSSIndexCompatibilityApi SDK only supports Basic by default.
+      const initOverrides: InitOverrideFunction | undefined = this.accessToken
+        ? async ({ init }) => ({ ...init, headers: { ...init.headers, Authorization: `Bearer ${this.accessToken}` } })
+        : undefined;
+      const response = await this.api.getComponentReports({ purlRequestPost: { coordinates: purls } }, initOverrides);
       return response as unknown as OssIndexServerResultJSON[];
     } catch (err) {
       const status =

--- a/src/Services/GuideRequestService.ts
+++ b/src/Services/GuideRequestService.ts
@@ -152,7 +152,8 @@ export class GuideRequestService {
 
     for (const chunk of chunkedPurls) {
       try {
-        const purls = chunk.map((x) => x.toPurl(format));
+        const purls = chunk.map((x) => x.toPurl(format)).filter((p) => /^[^@]+@\d+\.\d+\.\d+/.test(p));
+        if (purls.length === 0) continue;
         const res = this.getResultsFromGuide(purls);
         responses.push(res);
       } catch (e) {


### PR DESCRIPTION
Resolves #294 

cc @sonatype-nexus-community/auditjs
